### PR TITLE
[TASK] Streamline pages TCA

### DIFF
--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -2,7 +2,7 @@
 
 if (!isset($GLOBALS['TCA']['pages']['columns']['tx_realurl_pathsegment'])) {
 
-	$columns = array(
+	\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('pages', array(
 		'tx_realurl_pathsegment' => array(
 			'label' => 'LLL:EXT:realurl/Resources/Private/Language/locallang_db.xlf:pages.tx_realurl_pathsegment',
 			'displayCond' => 'FIELD:tx_realurl_exclude:!=:1',
@@ -43,29 +43,27 @@ if (!isset($GLOBALS['TCA']['pages']['columns']['tx_realurl_pathsegment'])) {
 				),
 			),
 		)
-	);
+	));
 
-	\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('pages', $columns);
+//  $GLOBALS['TCA']['pages']['ctrl']['requestUpdate'] .= ',tx_realurl_exclude';
 
-//	$GLOBALS['TCA']['pages']['ctrl']['requestUpdate'] .= ',tx_realurl_exclude';
+//  $GLOBALS['TCA']['pages']['palettes']['137'] = array(
+//    'showitem' => 'tx_realurl_pathoverride'
+//  );
 
-//	$TCA['pages']['palettes']['137'] = array(
-//		'showitem' => 'tx_realurl_pathoverride'
-//	);
-
-//	\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addFieldsToPalette('pages', '3', 'tx_realurl_nocache', 'after:cache_timeout');
-//	\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('pages', 'tx_realurl_pathsegment;;137;;,tx_realurl_exclude', '1', 'after:nav_title');
-//	\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('pages', 'tx_realurl_pathsegment;;137;;,tx_realurl_exclude', '4,199,254', 'after:title');
+//  \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addFieldsToPalette('pages', '3', 'tx_realurl_nocache', 'after:cache_timeout');
+//  \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('pages', 'tx_realurl_pathsegment;;137;;,tx_realurl_exclude', '1', 'after:nav_title');
+//  \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('pages', 'tx_realurl_pathsegment;;137;;,tx_realurl_exclude', '4,199,254', 'after:title');
 
 
-	$TCA['pages']['palettes']['137'] = array(
+	$GLOBALS['TCA']['pages']['palettes']['137'] = array(
 		'showitem' => ''
 	);
 
 	\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('pages', 'tx_realurl_pathsegment;;137;;', '1', 'after:nav_title');
 	\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('pages', 'tx_realurl_pathsegment;;137;;', '4,199,254', 'after:title');
 
-	$columns = array(
+	\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('pages_language_overlay', array(
 		'tx_realurl_pathsegment' => array(
 			'label' => 'LLL:EXT:realurl/Resources/Private/Language/locallang_db.xlf:pages.tx_realurl_pathsegment',
 			'exclude' => 1,
@@ -75,11 +73,7 @@ if (!isset($GLOBALS['TCA']['pages']['columns']['tx_realurl_pathsegment'])) {
 				'eval' => 'trim,nospace,lower'
 			),
 		),
-	);
-
-	\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('pages_language_overlay', $columns);
+	));
 
 	\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('pages_language_overlay', 'tx_realurl_pathsegment', '', 'after:nav_title');
-
-	unset($columns);
 }


### PR DESCRIPTION
Drop unnecessary variables and always use $GLOBALS['TCA']