### PR TITLE
[BUGFIX] Fix ignored config for fixedPostVars

### DIFF
--- a/Classes/EncodeDecoderBase.php
+++ b/Classes/EncodeDecoderBase.php
@@ -144,7 +144,7 @@ abstract class EncodeDecoderBase {
 		if (is_null($configurationBlock) && isset($configuration['_DEFAULT'])) {
 			$configurationBlock = $configuration['_DEFAULT'];
 		}
-		else {
+		else if (is_null($configurationBlock)) {
 			$configurationBlock = array();
 		}
 


### PR DESCRIPTION
Hello Dmitry

The config for fixedPostVars does not work if I do it according to the old docs.
My config looks like this (its not finished, but at least it works after my change)
```
'fixedPostVars' => array(
	'newsDetail' => array(
		array(
			'GETvar' => 'tx_news_pi1[day]',
		),
		array(
			'GETvar' => 'tx_news_pi1[month]',
		),
		array(
			'GETvar' => 'tx_news_pi1[year]',
		),
		array(
			'GETvar' => 'tx_news_pi1[news]',
			'lookUpTable' => array(
				'table' => 'tx_news_domain_model_news',
				'id_field' => 'uid',
				'alias_field' => 'CONCAT(title, "-", uid)',
				'addWhereClause' => ' AND NOT deleted',
				'useUniqueCache' => 1,
				'useUniqueCache_conf' => array(
					'strtolower' => 1,
					'spaceCharacter' => '-'
				),
				'languageGetVar' => 'L',
				'languageExceptionUids' => '',
				'languageField' => 'sys_language_uid',
				'transOrigPointerField' => 'l10n_parent',
				'autoUpdate' => 1,
			)
		),
		array(
			'GETvar' => 'tx_news_pi1[controller]'
		),
		array(
			'GETvar' => 'tx_news_pi1[action]'
		)
	),
	'12' => 'newsDetail'
),
```

I slightly altered the control structure so the array will not be overwritten with an empty array if there is already something in it.

If it is intended that the old config does not work, please let me know the needed changes.

Thanks, René