### PR TITLE
Add "exclude page path" function

### DIFF
--- a/Classes/Decoder/UrlDecoder.php
+++ b/Classes/Decoder/UrlDecoder.php
@@ -995,10 +995,10 @@ class UrlDecoder extends EncodeDecoderBase {
 
 	/**
 	 * Find a page entry for the current segment and returns a PathCacheEntry for it.
-	 * @param type $segment
-	 * @param type $pages
-	 * @param type $collectedPageIds
-	 * @return type
+	 * @param string $segment
+	 * @param array $pages
+	 * @param array $collectedPageIds
+	 * @return \DmitryDulepov\\Realurl\\Cache\\PathCacheEntry | NULL
 	 */
 	public function createPathCacheEntry($segment, $pages, &$collectedPageIds) {
 		$result = NULL;
@@ -1026,12 +1026,12 @@ class UrlDecoder extends EncodeDecoderBase {
 
 	/**
 	 * Searches a page below excluded pages and returns the PathCacheEntry if something was found.
-	 * @param type $segment
-	 * @param type $pages
-	 * @param type $collectedPageIds
-	 * @param type $disallowedDoktypes
-	 * @param type $pagesEnableFields
-	 * @return type
+	 * @param string $segment
+	 * @param array $pages
+	 * @param array $collectedPageIds
+	 * @param string $disallowedDoktypes
+	 * @param string $pagesEnableFields
+	 * @return \DmitryDulepov\\Realurl\\Cache\\PathCacheEntry | NULL
 	 */
 	public function getPathCacheEntryAfterExcludedPages($segment, $pages, &$collectedPageIds, $disallowedDoktypes, $pagesEnableFields) {
 		$ids = array();

--- a/Classes/Decoder/UrlDecoder.php
+++ b/Classes/Decoder/UrlDecoder.php
@@ -965,25 +965,9 @@ class UrlDecoder extends EncodeDecoderBase {
 		$pages = $this->databaseConnection->exec_SELECTgetRows('*', 'pages', 'pid=' . (int)$currentPid .
 			' AND doktype NOT IN (' . $disallowedDoktypes . ')' . $pagesEnableFields
 		);
-		foreach ($pages as $page) {
-			if ($page['doktype'] == PageRepository::DOKTYPE_SHORTCUT) {
-				$page = $this->resolveShortcut($page);
-			}
-			$collectedPageIds[] = (int)$page['uid'];
-			if (!$result) {
-				foreach (self::$pageTitleFields as $field) {
-					if ($this->utility->convertToSafeString($page[$field]) == $segment) {
-						$result = GeneralUtility::makeInstance('DmitryDulepov\\Realurl\\Cache\\PathCacheEntry');
-						/** @var \DmitryDulepov\Realurl\Cache\PathCacheEntry $cacheEntry */
-						$result->setPageId((int)$page['uid']);
-						if ($this->detectedLanguageId > 0) {
-							break;
-						} else {
-							break 2;
-						}
-					}
-				}
-			}
+		$result = $this->createPathCacheEntry($segment, $pages, $collectedPageIds);
+		if (!$result) {
+			$result = $this->getPathCacheEntryAfterExcludedPages($segment, $pages, $collectedPageIds, $disallowedDoktypes, $pagesEnableFields);
 		}
 
 		// We have to search overlay as well
@@ -1006,6 +990,76 @@ class UrlDecoder extends EncodeDecoderBase {
 			}
 		}
 
+		return $result;
+	}
+
+	/**
+	 * Find a page entry for the current segment and returns a PathCacheEntry for it.
+	 * @param type $segment
+	 * @param type $pages
+	 * @param type $collectedPageIds
+	 * @return type
+	 */
+	public function createPathCacheEntry($segment, $pages, &$collectedPageIds) {
+		$result = NULL;
+		foreach ($pages as $page) {
+			if ($page['doktype'] == PageRepository::DOKTYPE_SHORTCUT) {
+				$page = $this->resolveShortcut($page);
+			}
+			$collectedPageIds[] = (int) $page['uid'];
+			foreach (self::$pageTitleFields as $field) {
+				if ($this->utility->convertToSafeString($page[$field]) == $segment) {
+					$result = GeneralUtility::makeInstance('DmitryDulepov\\Realurl\\Cache\\PathCacheEntry');
+					/** @var \DmitryDulepov\Realurl\Cache\PathCacheEntry $cacheEntry */
+					$result->setPageId((int) $page['uid']);
+					if ($this->detectedLanguageId > 0) {
+						break;
+					} else {
+						break 2;
+					}
+				}
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Searches a page below excluded pages and returns the PathCacheEntry if something was found.
+	 * @param type $segment
+	 * @param type $pages
+	 * @param type $collectedPageIds
+	 * @param type $disallowedDoktypes
+	 * @param type $pagesEnableFields
+	 * @return type
+	 */
+	public function getPathCacheEntryAfterExcludedPages($segment, $pages, &$collectedPageIds, $disallowedDoktypes, $pagesEnableFields) {
+		$ids = array();
+		$result = array();
+		$newPages = $pages;
+
+		while ($newPages) {
+			foreach ($newPages as $page) {
+				if ($page['tx_realurl_exclude']) {
+					$ids[] = $page['uid'];
+				}
+			}
+			if ($ids) {
+				$children = $this->databaseConnection->exec_SELECTgetRows(
+						'*', 'pages', 'pid IN(' . implode(',', $ids) . ')' .
+						' AND doktype NOT IN (' . $disallowedDoktypes . ')' . $pagesEnableFields
+				);
+
+				$result = $this->createPathCacheEntry($segment, $children, $collectedPageIds);
+				if ($result) {
+					break;
+				}
+				$newPages = $children;
+				$ids = array();
+			} else {
+				break;
+			}
+		}
 		return $result;
 	}
 
@@ -1108,4 +1162,5 @@ class UrlDecoder extends EncodeDecoderBase {
 		// TODO Write to our own error log here
 		$this->caller->pageNotFoundAndExit($errorMessage);
 	}
+
 }

--- a/Classes/Encoder/UrlEncoder.php
+++ b/Classes/Encoder/UrlEncoder.php
@@ -362,6 +362,10 @@ class UrlEncoder extends EncodeDecoderBase {
 
 		$components = array();
 		foreach (array_reverse($rootLine) as $page) {
+			// Skip if this page is excluded
+			if ($page['tx_realurl_exclude']) {
+				continue;
+			}
 			if ($enableLanguageOverlay) {
 				$overlay = $this->pageRepository->getPageOverlay($page, (int)$this->originalUrlParameters['L']);
 				if (is_array($overlay)) {

--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -45,15 +45,15 @@ if (!isset($GLOBALS['TCA']['pages']['columns']['tx_realurl_pathsegment'])) {
 		)
 	));
 
-//  $GLOBALS['TCA']['pages']['ctrl']['requestUpdate'] .= ',tx_realurl_exclude';
+  $GLOBALS['TCA']['pages']['ctrl']['requestUpdate'] .= ',tx_realurl_exclude';
 
 //  $GLOBALS['TCA']['pages']['palettes']['137'] = array(
 //    'showitem' => 'tx_realurl_pathoverride'
 //  );
 
 //  \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addFieldsToPalette('pages', '3', 'tx_realurl_nocache', 'after:cache_timeout');
-//  \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('pages', 'tx_realurl_pathsegment;;137;;,tx_realurl_exclude', '1', 'after:nav_title');
-//  \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('pages', 'tx_realurl_pathsegment;;137;;,tx_realurl_exclude', '4,199,254', 'after:title');
+  \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('pages', 'tx_realurl_pathsegment;;137;;,tx_realurl_exclude', '1', 'after:nav_title');
+  \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('pages', 'tx_realurl_pathsegment;;137;;,tx_realurl_exclude', '4,199,254', 'after:title');
 
 
 	$GLOBALS['TCA']['pages']['palettes']['137'] = array(


### PR DESCRIPTION
I activated the "Exclude from speaking URL" again and implemented it into encoder and decoder.

Since the excluded pages are not the default behavior, it will only search for them when nothing else was found. This should save some time on most page loads.