### PR TITLE
apiwrappers Compatibility for Typo3 6.1

### DIFF
--- a/apiwrappers/class.tx_realurl_apiwrapper_6x.php
+++ b/apiwrappers/class.tx_realurl_apiwrapper_6x.php
@@ -231,7 +231,11 @@ class tx_realurl_apiwrapper_6x extends tx_realurl_apiwrapper implements \TYPO3\C
 	 * @return array
 	 */
 	public function array_merge_recursive_overrule($array1, $array2) {
-		\TYPO3\CMS\Core\Utility\ArrayUtility::mergeRecursiveWithOverrule($array1, $array2);
+		if (version_compare(TYPO3_branch, '6.2', '<')) {
+			$array1 = GeneralUtility::array_merge_recursive_overrule($array1, $array2);
+		} else {
+			\TYPO3\CMS\Core\Utility\ArrayUtility::mergeRecursiveWithOverrule($array1, $array2);
+		}
 		return $array1;
 	}
 


### PR DESCRIPTION
Hi,

we were able to use the extension with Typo3 6.1.7 only with this patch, as \TYPO3\CMS\Core\Utility\ArrayUtility::mergeRecursiveWithOverrule isn't defined here.