### PR TITLE
[TASK] Add "replace" section to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,10 @@
         "typo3",
         "realurl"
     ],
+    "replace": {
+        "realurl": "self.version",
+        "typo3-ter/realurl": "self.version"
+    },
     "require": {
         "typo3/cms-core": ">=6.2.0,<8.0",
         "php": ">=5.3.2"


### PR DESCRIPTION
This ensures that dependencies on these alternative package names can be resolved
in any case.

This is also essential for the TYPO3 composer installers to determine the extension 
name for installation via Composer vcs repository.