### PR TITLE
[BUGFIX] Allow DOKTYPE_SPACER to have subpages

### DIFF
--- a/Classes/Decoder/UrlDecoder.php
+++ b/Classes/Decoder/UrlDecoder.php
@@ -1211,7 +1211,7 @@ class UrlDecoder extends EncodeDecoderBase {
 		$resultForCache = null;
 
 		$collectedPageIds = array(); $shortcutPages = array();
-		$disallowedDoktypes = PageRepository::DOKTYPE_RECYCLER . ',' . PageRepository::DOKTYPE_SPACER;
+		$disallowedDoktypes = PageRepository::DOKTYPE_RECYCLER;
 		$pagesEnableFields = $this->pageRepository->enableFields('pages');
 		$pages = $this->databaseConnection->exec_SELECTgetRows('*', 'pages', 'pid=' . (int)$currentPid .
 			' AND doktype NOT IN (' . $disallowedDoktypes . ')' . $pagesEnableFields


### PR DESCRIPTION
Menu seperator can also be used as container for other pages

Resolves: #50 