### PR TITLE
[BUGFIX] Fix DataHandler hook cache handling

### DIFF
--- a/Classes/Hooks/DataHandler.php
+++ b/Classes/Hooks/DataHandler.php
@@ -120,7 +120,6 @@ class DataHandler implements SingletonInterface {
 			while (FALSE !== ($data = $this->databaseConnection->sql_fetch_assoc($result))) {
 				if ($data['url_cache_id']) {
 					$this->cache->clearUrlCacheById($data['url_cache_id']);
-					$this->databaseConnection->exec_DELETEquery('tx_realurl_uniqalias_cache_map', 'uid=' . (int)$data['uid']);
 				}
 				if ((int)$data['expire'] === 0) {
 					$this->databaseConnection->exec_UPDATEquery('tx_realurl_uniqalias', 'uid=' . (int)$data['uid'], array(


### PR DESCRIPTION
The DataHandler - Hook issued a superfluous DELETE query that used
a non-existent field `uid`.

The call was removed completely since the cache backend handles the same
table entries in the line above.