### PR TITLE
Only do the Decoding if no beUser present

### DIFF
--- a/Classes/Configuration/ConfigurationReader.php
+++ b/Classes/Configuration/ConfigurationReader.php
@@ -190,14 +190,16 @@ class ConfigurationReader {
 		$globalConfig = &$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl'];
 		foreach ($globalConfig['_DOMAINS']['decode'] as $domainName => $configuration) {
 			$checkThisConfiguration = false;
-			if ($domainName{0} == '/') {
-				// Regular expression, match only main host name
-				if (@preg_match($domainName, $this->hostName)) {
+			if($GLOBALS['TSFE']->beUserLogin < 1 || !$GLOBALS['TSFE']->beUserLogin){
+				if ($domainName{0} == '/') {
+					// Regular expression, match only main host name
+					if (@preg_match($domainName, $this->hostName)) {
+						$checkThisConfiguration = true;
+					}
+				}
+				elseif ($domainName === $this->hostName || $domainName === $this->alternativeHostName) {
 					$checkThisConfiguration = true;
 				}
-			}
-			elseif ($domainName === $this->hostName || $domainName === $this->alternativeHostName) {
-				$checkThisConfiguration = true;
 			}
 			if ($checkThisConfiguration) {
 				if (isset($configuration['useConfiguration']) && isset($globalConfig[$configuration['useConfiguration']])) {

--- a/Classes/Configuration/ConfigurationReader.php
+++ b/Classes/Configuration/ConfigurationReader.php
@@ -190,7 +190,7 @@ class ConfigurationReader {
 		$globalConfig = &$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl'];
 		foreach ($globalConfig['_DOMAINS']['decode'] as $domainName => $configuration) {
 			$checkThisConfiguration = false;
-			if($GLOBALS['TSFE']->beUserLogin < 1 || !$GLOBALS['TSFE']->beUserLogin){
+			if(!$GLOBALS['TSFE']->beUserLogin){
 				if ($domainName{0} == '/') {
 					// Regular expression, match only main host name
 					if (@preg_match($domainName, $this->hostName)) {


### PR DESCRIPTION
The preview page would constantly overwrite L var's, which will not allow language switching while previewing. I guess it is safe to remove the decode when logged in. Else, it works as expected.

Cheers