### PR TITLE
Performance tuning and Bugfixing

### DIFF
--- a/Classes/Cache/DatabaseCache.php
+++ b/Classes/Cache/DatabaseCache.php
@@ -139,15 +139,6 @@ class DatabaseCache implements CacheInterface, SingletonInterface {
 			$requestVariables = json_decode($row['request_variables'], TRUE);
 			// TODO Log a problem here because it must be an array always
 			$cacheEntry->setRequestVariables(is_array($requestVariables) ? $requestVariables : array());
-
-			// Update timestamp
-			$currentTime = time();
-			if ((int)$row['tstamp'] !== $currentTime) {
-				$this->databaseConnection->exec_UPDATEquery('tx_realurl_urlcache',
-					'uid=' . $this->databaseConnection->fullQuoteStr($cacheEntry->getCacheId(), 'tx_realurl_urlcache'),
-					array('tstamp' => $currentTime)
-				);
-			}
 		}
 
 		return $cacheEntry;
@@ -177,15 +168,6 @@ class DatabaseCache implements CacheInterface, SingletonInterface {
 			$requestVariables = json_decode($row['request_variables'], TRUE);
 			// TODO Log a problem here because it must be an array always
 			$cacheEntry->setRequestVariables(is_array($requestVariables) ? $requestVariables : array());
-
-			// Update timestamp
-			$currentTime = time();
-			if ((int)$row['tstamp'] !== $currentTime) {
-				$this->databaseConnection->exec_UPDATEquery('tx_realurl_urlcache',
-					'uid=' . $this->databaseConnection->fullQuoteStr($cacheEntry->getCacheId(), 'tx_realurl_urlcache'),
-					array('tstamp' => $currentTime)
-				);
-			}
 		}
 
 		return $cacheEntry;

--- a/Classes/Decoder/UrlDecoder.php
+++ b/Classes/Decoder/UrlDecoder.php
@@ -257,27 +257,6 @@ class UrlDecoder extends EncodeDecoderBase {
 			}
 		}
 
-		if (!is_int($result)) {
-			// If no cached entry, look it up directly in the table. Note: this will
-			// most likely fail. When encoding we convert alias field to a nice
-			// looking URL segment, which usually looks differently from the field.
-			// But this is the only thing we can do without fetching each record and
-			// re-encoding the field to find the match.
-			$fieldList[] = $configuration['id_field'];
-			$row = $this->databaseConnection->exec_SELECTgetSingleRow(implode(',', $fieldList),
-				$configuration['table'],
-				$configuration['alias_field'] . '=' . $this->databaseConnection->fullQuoteStr($value, $configuration['table']) .
-				' ' . $configuration['addWhereClause']);
-			if (is_array($row)) {
-				$result = (int)$row[$configuration['id_field']];
-
-				// If localization is enabled, check if this record is a localized version and if so, find uid of the original version.
-				if ($translationEnabled && $row[$configuration['languageField']] > 0) {
-					$result = (int)$row[$configuration['transOrigPointerField']];
-				}
-			}
-		}
-
 		return $result;
 	}
 
@@ -1225,7 +1204,7 @@ class UrlDecoder extends EncodeDecoderBase {
 				$result = GeneralUtility::makeInstance('DmitryDulepov\\Realurl\\Cache\\PathCacheEntry');
 				/** @var \DmitryDulepov\Realurl\Cache\PathCacheEntry $result */
 				$result->setLanguageId($this->detectedLanguageId);
-				$result->setPageId((int)$row['pid']);
+				$result->setPageId((int)$row['uid']);
 				$result->setPagePath($path);
 				$result->setRootPageId($this->rootPageId);
 				break;

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -35,6 +35,7 @@ if (!function_exists('includeRealurlConfiguration')) {
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tstemplate.php']['linkData-PostProc']['realurl'] = 'DmitryDulepov\\Realurl\\Encoder\\UrlEncoder->encodeUrl';
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_content.php']['typoLink_PostProc']['realurl'] = 'DmitryDulepov\\Realurl\\Encoder\\UrlEncoder->postProcessEncodedUrl';
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['checkAlternativeIdMethods-PostProc']['realurl'] = 'DmitryDulepov\\Realurl\\Decoder\\UrlDecoder->decodeUrl';
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['realurl']['cacheImplementation'] = 'DmitryDulepov\\Realurl\\Cache\\DatabaseCache';
 
 includeRealurlConfiguration();
 
@@ -43,7 +44,6 @@ $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['clea
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass']['realurl'] = 'DmitryDulepov\\Realurl\\Hooks\\DataHandler';
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processCmdmapClass']['realurl'] = 'DmitryDulepov\\Realurl\\Hooks\\DataHandler';
 
-$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['realurl']['cacheImplementation'] = 'DmitryDulepov\\Realurl\\Cache\\DatabaseCache';
 
 $GLOBALS['TYPO3_CONF_VARS']['FE']['addRootLineFields'] .= ',tx_realurl_pathsegment,tx_realurl_exclude,tx_realurl_pathoverride';
 $GLOBALS['TYPO3_CONF_VARS']['FE']['pageOverlayFields'] .= ',tx_realurl_pathsegment';


### PR DESCRIPTION
* make cacheImplementation before includeRealurlConfiguration so that developers can use their own by define the class in configuration file
* there is no need to lookup for alias_field directly in the table. in 99 percent it will fail, but is a performance killer if your tables are huge (mio. of rows)
* also there is no need to update the tstamp in tx_realurl_urlcache table on every page request multiple times