### PR TITLE
Make detectedLanguageId available in 404 case

### DIFF
--- a/Classes/Decoder/UrlDecoder.php
+++ b/Classes/Decoder/UrlDecoder.php
@@ -1376,6 +1376,8 @@ class UrlDecoder extends EncodeDecoderBase {
 	 */
 	protected function throw404($errorMessage) {
 		// TODO Write to our own error log here
+		// Register the detectedLanguageId
+		$this->caller->register['realurl_detectedLanguageId'] = $this->detectedLanguageId;
 		$this->caller->pageNotFoundAndExit($errorMessage);
 	}
 }


### PR DESCRIPTION
On multilanguage websites, the "L" is configured in preVars very often. Because of this, when realurl comes to the most common 404 errors (not existing postVarSet), the preVars are decoded already.

Now, within my ext [pagenotfoundhandling](https://forge.typo3.org/projects/extension-pagenotfoundhandling), I want to be able to deliver the 404 page in the correct language. But when realurl throws the 404, I can't, because there is no "L" in $_GET.

The proposed solution would be a pretty straightforward one, I know. But the problem is gone for low cost and complexity ;-)

What do you think?
