### PR TITLE
Fix pagetitle "0" preventing encoding/decoding.

### DIFF
--- a/class.tx_realurl_advanced.php
+++ b/class.tx_realurl_advanced.php
@@ -625,7 +625,7 @@ class tx_realurl_advanced {
 					$segTitleFieldArray = $this->apiWrapper->trimExplode(',', $this->conf['segTitleFieldList'] ? $this->conf['segTitleFieldList'] : TX_REALURL_SEGTITLEFIELDLIST_DEFAULT, 1);
 					$theTitle = '';
 					foreach ($segTitleFieldArray as $fieldName) {
-						if ($page[$fieldName]) {
+						if (isset($page[$fieldName]) && $page[$fieldName] !== '') {
 							$theTitle = $page[$fieldName];
 							break;
 						}
@@ -1078,7 +1078,7 @@ class tx_realurl_advanced {
 				// otherwise they will never be found
 				$uidTrack[$row['uid']] = $row;
 				foreach ($segTitleFieldArray as $fieldName) {
-					if ($row[$fieldName]) {
+					if (isset($row[$fieldName]) && $row[$fieldName] !== '') {
 						$encodedTitle = $this->encodeTitle($row[$fieldName]);
 						if (!isset($titles[$fieldName][$encodedTitle])) {
 							$titles[$fieldName][$encodedTitle] = $row['uid'];


### PR DESCRIPTION
Pages with title "0" cannot be encoded/decoded (and thus, not viewed) due to a not-type-safe if () comparision.

Our T3 still uses realurl 1.x due to compatibility issues that we haven't gotten around to fixing. Perhaps someone who knows where the relevant code lines are in the 2.x line can quickly insert the fix there, if necessary.