### PR TITLE
[BUGFIX] urldecode path segments separately

### DIFF
--- a/Classes/Decoder/UrlDecoder.php
+++ b/Classes/Decoder/UrlDecoder.php
@@ -782,9 +782,12 @@ class UrlDecoder extends EncodeDecoderBase {
 	 * @return UrlCacheEntry with only pageId and requestVariables filled in
 	 */
 	protected function doDecoding($path) {
-		// Remember: urldecode(), not rawurldecode()!
-		$path = trim(urldecode($path), '/');
+		$path = trim($path, '/');
 		$pathSegments = $path ? explode('/', $path) : array();
+		// Remember: urldecode(), not rawurldecode()!
+		foreach($pathSegments as $id => $value) {
+			$pathSegments[$id] = urldecode($value);
+		}
 
 		$requestVariables = array();
 


### PR DESCRIPTION
On decoding, the full scriptpath is handeld by urldecode(). After this,
the slash '/' is used as separator. Doing this way, realurl cannot
handle proper escaped slashes in values.

This patch does the decoding on every value separately as it did realUrl
1.x.

Imagin this scenario:

http://example.com/doc/http%3A%2F%2Fanotherexample.com%2Fapi%2Fdoc%3A123%2F6%2F/

On page doc, the following fixed post vars are configures:

'fixedPostVars' = array(
	'presentationConfiguration' => array(
                'docid' => array(
                        'GETvar' => 'tx_example[docid]',
                        ),
        ),
	20 => 'presentationConfiguration',
),

The extensions needs to get the passed URL in variable
tx_example[docid].