### PR TITLE
fix wrong/default language value on new cache entry

### DIFF
--- a/Classes/Decoder/UrlDecoder.php
+++ b/Classes/Decoder/UrlDecoder.php
@@ -1122,6 +1122,7 @@ class UrlDecoder extends EncodeDecoderBase {
 		if (!$cacheEntry) {
 			$cacheEntry = $newCacheEntry;
 			$cacheEntry->setRootPageId($this->rootPageId);
+			$cacheEntry->setLanguageId($this->detectedLanguageId);
 		}
 		if ($cacheEntry->getExpiration() !== 0) {
 			$cacheEntry->setExpiration(0);


### PR DESCRIPTION
Description/How to reproduce:
* Multilanguage Site
* there is absolutely NO cache entry (tx_realurl_pathcache, tx_realurl_urlcache)
* user get linked from e.g. google on specific page in non default languge
* real url get the right path to page, but save the path in default language (zero)
Result is:
* the saved path is now used to make URL for default language
Example:
http://www.example.com/en/contact.html
switch to default language results to:
http://www.example.com/de/contact.html instead of http://www.example.com/de/kontakt.html