### PR TITLE
Remove field `tstamp` UrlEncoder.php

### DIFF
--- a/Classes/Encoder/UrlEncoder.php
+++ b/Classes/Encoder/UrlEncoder.php
@@ -1136,7 +1136,6 @@ class UrlEncoder extends EncodeDecoderBase {
 
 			// Store new alias
 			$insertArray = array(
-				'tstamp' => time(),
 				'tablename' => $configuration['table'],
 				'field_alias' => $configuration['alias_field'],
 				'field_id' => $configuration['id_field'],


### PR DESCRIPTION
In File Classes/Encoder/UrlEncoder.php the $insertArray contains the field `tstamp`, but ext_tables.sql doesn't define any `tstamp` field. So I think line 1139 (related to commit ed9086ae) should be deleted.