### PR TITLE
Language Fallback for non-ascii languages

### DIFF
--- a/Classes/Decoder/UrlDecoder.php
+++ b/Classes/Decoder/UrlDecoder.php
@@ -308,7 +308,13 @@ class UrlDecoder extends EncodeDecoderBase {
 				}
 			}
 			if ($this->detectedLanguageId > 0 && !isset($page['_PAGES_OVERLAY'])) {
-				$page = $this->pageRepository->getPageOverlay($page, (int)$this->detectedLanguageId);
+
+				$overlayLanguage = (int)$this->detectedLanguageId;
+				if(isset($this->configuration->get('pagePath/languageFallback')[$overlayLanguage])) {
+					$overlayLanguage = $this->configuration->get('pagePath/languageFallback')[$overlayLanguage];
+				}
+
+				$page = $this->pageRepository->getPageOverlay($page, $overlayLanguage);
 			}
 			foreach (self::$pageTitleFields as $field) {
 				if (isset($page[$field]) && $page[$field] !== '' && $this->utility->convertToSafeString($page[$field], $this->separatorCharacter) === $segment) {

--- a/Classes/Encoder/UrlEncoder.php
+++ b/Classes/Encoder/UrlEncoder.php
@@ -441,8 +441,13 @@ class UrlEncoder extends EncodeDecoderBase {
 			if ($page['tx_realurl_exclude'] && $current !== $rootLineMax) {
 				continue;
 			}
+
 			if ($enableLanguageOverlay) {
-				$overlay = $this->pageRepository->getPageOverlay($page, (int)$this->originalUrlParameters['L']);
+				$overlayLanguage = (int)$this->originalUrlParameters['L'];
+				if(isset($this->configuration->get('pagePath/languageFallback')[(int)$this->originalUrlParameters['L']])) {
+					$overlayLanguage = $this->configuration->get('pagePath/languageFallback')[(int)$this->originalUrlParameters['L']];
+				}
+				$overlay = $this->pageRepository->getPageOverlay($page, $overlayLanguage);
 				if (is_array($overlay)) {
 					$page = $overlay;
 					unset($overlay);
@@ -915,8 +920,8 @@ class UrlEncoder extends EncodeDecoderBase {
 						else {
 							$this->encodedUrl = rtrim($this->encodedUrl, '/');
 						}
-						$this->encodedUrl .= $fileName;
 					}
+					$this->encodedUrl .= $fileName;
 					$this->urlParameters = array_diff_key($this->urlParameters, $variablesToRemove);
 					$result = TRUE;
 					break;

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -7,58 +7,6 @@ if (!defined('TX_REALURL_AUTOCONF_FILE')) {
 if (!function_exists('includeRealurlConfiguration')) {
 
 	/**
-	 * Makes sure that some known USER_INT plugins are not included to cHash
-	 * calculation. This will dynamically adjust variables if certain
-	 * parameters are found in the URL. This is useful for decoding only when
-	 * there is no URL cache entry for the URL because in such case these
-	 * parameters will create a cHash.
-	 *
-	 * @return void
-	 * @see \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController::makeCacheHash()
-	 */
-	function tx_realurl_fixCacheHashExcludeList() {
-		$excludeList = &$GLOBALS['TYPO3_CONF_VARS']['FE']['cHashExcludedParameters'];
-		$excludeArray = \TYPO3\CMS\Core\Utility\GeneralUtility::trimExplode(',', (string)$excludeList, true);
-		$newExcludeArray = $excludeArray;
-
-		$knownUserIntParameterPrefixes = array(
-			'tx_felogin_pi1',
-			'tx_form_form',
-			'tx_indexedsearch',
-			'tx_solr'
-		);
-		$knownUserIntParameters = array(
-			'q', // solr
-		);
-
-		foreach ($knownUserIntParameterPrefixes as $userIntParameterPrefix) {
-			$urlParameters = \TYPO3\CMS\Core\Utility\GeneralUtility::_GET($userIntParameterPrefix);
-			if (is_array($urlParameters)) {
-				foreach (array_keys($urlParameters) as $parameterName) {
-					$fullParameterName = $userIntParameterPrefix . '[' . $parameterName . ']';
-					if (!in_array($fullParameterName, $newExcludeArray)) {
-						$newExcludeArray[] = $fullParameterName;
-					}
-				}
-				unset($parameterName, $urlParameters);
-			}
-		}
-		foreach ($knownUserIntParameters as $userIntParameter) {
-			$urlParameter = \TYPO3\CMS\Core\Utility\GeneralUtility::_GET($userIntParameter);
-			if (is_string($urlParameter) && !in_array($userIntParameter, $newExcludeArray)) {
-				$newExcludeArray[] = $userIntParameter;
-			}
-		}
-
-		if (count($newExcludeArray) !== count($excludeArray)) {
-			$excludeList = implode(',', $newExcludeArray);
-			if (is_array($GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['excludedParameters'])) {
-				$GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['excludedParameters'] = $newExcludeArray;
-			}
-		}
-	}
-
-	/**
 	 * Includes RealURL configuration.
 	 *
 	 * @return void
@@ -92,7 +40,6 @@ $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_content.php']['typo
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['checkAlternativeIdMethods-PostProc']['realurl'] = 'DmitryDulepov\\Realurl\\Decoder\\UrlDecoder->decodeUrl';
 
 includeRealurlConfiguration();
-tx_realurl_fixCacheHashExcludeList();
 
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['clearCachePostProc']['realurl_all_caches'] = 'DmitryDulepov\\Realurl\\Hooks\\Cache->clearUrlCache';
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['clearCachePostProc']['realurl_records'] = 'DmitryDulepov\\Realurl\\Hooks\\Cache->clearUrlCacheForRecords';


### PR DESCRIPTION
When using japanese or chinese (or any non-ascii supporting language), realurl will simply encode the page names to the request query.

This is quite annoying, since this will never work (this is known since some years now). There used to be an option called languageExceptionUids, but it doesn't exist anymore, so I built it again.

What has to be done to work properly is that you have to add this to the pagePath Configuration part:
```
'languageFallback' => [
	'6' => 1,
	'7' => 1,
],
```