### PR TITLE
Fixed bug in auto configurator, selecting wrong field for lang iso code

### DIFF
--- a/Classes/Configuration/AutomaticConfigurator.php
+++ b/Classes/Configuration/AutomaticConfigurator.php
@@ -83,7 +83,7 @@ class AutomaticConfigurator {
 		if ($this->hasStaticInfoTables) {
 			$languages = $this->databaseConnection->exec_SELECTgetRows('t1.uid AS uid,t2.lg_iso_2 AS lg_iso_2', 'sys_language t1, static_languages t2', 't2.uid=t1.static_lang_isocode AND t1.hidden=0');
 		} else {
-			$languages = $this->databaseConnection->exec_SELECTgetRows('t1.uid AS uid,t1.uid AS lg_iso_2', 'sys_language t1', 't1.hidden=0');
+			$languages = $this->databaseConnection->exec_SELECTgetRows('t1.uid AS uid,t1.language_isocode AS lg_iso_2', 'sys_language t1', 't1.hidden=0');
 		}
 		if (count($languages) > 0) {
 			$configuration['preVars'] = array(


### PR DESCRIPTION
When creating the auto configuration for realurl there is a bug in the language select query, where the uid is falsly selected for the language_isocode.