### PR TITLE
[BUGFIX] Fix #175: Allow same pathsegment for different languages

### DIFF
--- a/Configuration/TCA/Overrides/pages_language_overlay.php
+++ b/Configuration/TCA/Overrides/pages_language_overlay.php
@@ -8,7 +8,7 @@ if (!isset($GLOBALS['TCA']['pages_language_overlay']['columns']['tx_realurl_path
 			'config' => array(
 				'type' => 'input',
 				'max' => 255,
-				'eval' => 'trim,nospace,lower,uniqueInPid,DmitryDulepov\\Realurl\\Evaluator\\SegmentFieldCleaner'
+				'eval' => 'trim,nospace,lower,DmitryDulepov\\Realurl\\Evaluator\\SegmentFieldCleaner'
 			),
 		),
 	));


### PR DESCRIPTION
Allow the same `tx_realurl_pathsegment` within the same pid for `pages_language_overlay`.  Different entries will still be different because of their `sys_language_uid`