### PR TITLE
Update DatabaseCache.php

### DIFF
--- a/Classes/Cache/DatabaseCache.php
+++ b/Classes/Cache/DatabaseCache.php
@@ -179,6 +179,9 @@ class DatabaseCache implements CacheInterface, SingletonInterface {
 					}
 				}
 			}
+			if(is_array($rows) && $row === null) {
+				$row = reset($rows);
+			}
 		}
 
 		if (is_array($row)) {


### PR DESCRIPTION
Fixes #162, we need a fallback if no Language Var is set otherwise we get more and more cacheentrys with the same fields wich causes the 404.