### PR TITLE
Use GeneralUtility::_GET() instead of $_GET

### DIFF
--- a/Classes/Decoder/UrlDecoder.php
+++ b/Classes/Decoder/UrlDecoder.php
@@ -1178,7 +1178,7 @@ class UrlDecoder extends EncodeDecoderBase {
 	 */
 	protected function mergeWithExistingGetVars(array &$requestVariables) {
 		if (count($_GET) > 0) {
-			$flatGetArray = $this->parseQueryStringParameters($this->createQueryStringFromParameters($_GET));
+			$flatGetArray = $this->parseQueryStringParameters($this->createQueryStringFromParameters(GeneralUtility::_GET()));
 			ArrayUtility::mergeRecursiveWithOverrule($requestVariables, $flatGetArray);
 		}
 	}


### PR DESCRIPTION
TYPO3 until TYPO3 version 6.2 adds slashes to values of super global $_GET
To avoid slashes added twice, the GeneralUtility::_GET() API method
must be used to obtain GET variable values.