### PR TITLE
[FEATURE] tx_realurl_pathoverride also used for urls of subpages

### DIFF
--- a/Classes/Encoder/UrlEncoder.php
+++ b/Classes/Encoder/UrlEncoder.php
@@ -483,6 +483,14 @@ class UrlEncoder extends EncodeDecoderBase {
 					unset($overlay);
 				}
 			}
+			// if pathoverride is set, use pathsegment also for all subpages to shorten the url and throw away all segments found so far
+			if ($page['tx_realurl_pathoverride'] && !empty($page['tx_realurl_pathsegment'])) {
+				$segment = $this->utility->convertToSafeString(trim($page['tx_realurl_pathsegment'], '/'), $this->separatorCharacter);
+				$components = array($segment);
+				continue;
+			}
+
+			
 			foreach (self::$pageTitleFields as $field) {
 				if (isset($page[$field]) && $page[$field] !== '') {
 					$segment = $this->utility->convertToSafeString($page[$field], $this->separatorCharacter);
@@ -490,13 +498,15 @@ class UrlEncoder extends EncodeDecoderBase {
 						$segment = $this->emptySegmentValue;
 					}
 					$components[] = $segment;
-					$this->appendToEncodedUrl($segment);
 					continue 2;
 				}
 			}
 		}
 
 		if (count($components) > 0) {
+			foreach ($components as $segment) {
+				$this->appendToEncodedUrl($segment);
+			}
 			$this->addToPathCache(implode('/', $components));
 		}
 	}


### PR DESCRIPTION
if tx_realurl_pathoverride is set, the url the the very page where it is set is reduced to the value given in tx_realurl_pathsegment. However urls to subpages are still generated with the full url, ignoring tx_realurl_pathoverride. This commit changes that. Also subpages start with the short path given in tx_realurl_pathsegment. 
The UrlDecoder already can handle these urls correctly.