### PR TITLE
Make "Disable RealURL cache" visible on page record edit form

### DIFF
--- a/ext_tables.php
+++ b/ext_tables.php
@@ -74,7 +74,7 @@ $GLOBALS['TCA']['pages']['palettes']['137'] = array(
 	'showitem' => 'tx_realurl_pathoverride'
 );
 
-$extensionMamagementUtility::addFieldsToPalette('pages', '3', 'tx_realurl_nocache', 'after:cache_timeout');
+$extensionMamagementUtility::addFieldsToPalette('pages', 'caching', 'tx_realurl_nocache', 'after:cache_timeout');
 $extensionMamagementUtility::addToAllTCAtypes('pages', 'tx_realurl_pathsegment;;137;;,tx_realurl_exclude', '1', 'after:nav_title');
 $extensionMamagementUtility::addToAllTCAtypes('pages', 'tx_realurl_pathsegment;;137;;,tx_realurl_exclude', '4,199,254', 'after:title');
 


### PR DESCRIPTION
In the TYPO3 edit page record page, the field `tx_realurl_nocache`
was not visible on TYPO3 7.6.