### PR TITLE
[FEATURE] Base for Testcases (based on configuration of extension_builder)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+/.gitattributes export-ignore
+/.travis.yml export-ignore
+/Tests/ export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.Build/*
+vendor/*
+composer.lock

--- a/Tests/Fixtures/realurl.xml
+++ b/Tests/Fixtures/realurl.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+	<sys_domain>
+		<uid>1</uid>
+		<pid>1</pid>
+		<domainName>www.example.com</domainName>
+	</sys_domain>
+<!--
+Page Tree:
+	- 1: Home
+		- 2: page2
+			- 5: subpage5-with-override (tx_realurl_pathoverride)
+			- 6: subpage6-with-alias (alias)
+			- 8: subpage8
+			- 9: 0 (Page with the title "0")
+		- 3: page3
+		- 4: page4 (tx_realurl_exclude=1)
+			- 7: subpage7-without-parent
+-->
+	<pages>
+		<uid>1</uid>
+		<pid>0</pid>
+		<doktype>1</doktype>
+		<deleted>0</deleted>
+		<title>Home</title>
+		<alias></alias>
+		<tx_realurl_pathsegment></tx_realurl_pathsegment>
+		<tx_realurl_pathoverride>0</tx_realurl_pathoverride>
+		<tx_realurl_exclude>0</tx_realurl_exclude>
+	</pages>
+	<pages>
+		<uid>2</uid>
+		<pid>1</pid>
+		<doktype>1</doktype>
+		<deleted>0</deleted>
+		<title>page2</title>
+		<alias></alias>
+		<tx_realurl_pathsegment></tx_realurl_pathsegment>
+		<tx_realurl_pathoverride>0</tx_realurl_pathoverride>
+		<tx_realurl_exclude>0</tx_realurl_exclude>
+	</pages>
+	<pages>
+		<uid>3</uid>
+		<pid>1</pid>
+		<doktype>1</doktype>
+		<deleted>0</deleted>
+		<title>page3</title>
+		<alias></alias>
+		<tx_realurl_pathsegment></tx_realurl_pathsegment>
+		<tx_realurl_pathoverride>0</tx_realurl_pathoverride>
+		<tx_realurl_exclude>0</tx_realurl_exclude>
+	</pages>
+	<pages>
+		<uid>4</uid>
+		<pid>1</pid>
+		<doktype>1</doktype>
+		<deleted>0</deleted>
+		<title>page4</title>
+		<alias></alias>
+		<tx_realurl_pathsegment></tx_realurl_pathsegment>
+		<tx_realurl_pathoverride>0</tx_realurl_pathoverride>
+		<tx_realurl_exclude>1</tx_realurl_exclude>
+	</pages>
+	<pages>
+		<uid>5</uid>
+		<pid>2</pid>
+		<doktype>1</doktype>
+		<deleted>0</deleted>
+		<title>subpage5-with-override</title>
+		<alias></alias>
+		<tx_realurl_pathsegment>page5-override</tx_realurl_pathsegment>
+		<tx_realurl_pathoverride>1</tx_realurl_pathoverride>
+		<tx_realurl_exclude>0</tx_realurl_exclude>
+	</pages>
+	<pages>
+		<uid>6</uid>
+		<pid>2</pid>
+		<doktype>1</doktype>
+		<deleted>0</deleted>
+		<title>subpage6-with-alias</title>
+		<alias>page6-alias</alias>
+		<tx_realurl_pathsegment></tx_realurl_pathsegment>
+		<tx_realurl_pathoverride>0</tx_realurl_pathoverride>
+		<tx_realurl_exclude>0</tx_realurl_exclude>
+	</pages>
+	<pages>
+		<uid>7</uid>
+		<pid>4</pid>
+		<doktype>1</doktype>
+		<deleted>0</deleted>
+		<title>subpage7-without-parent</title>
+		<alias></alias>
+		<tx_realurl_pathsegment></tx_realurl_pathsegment>
+		<tx_realurl_pathoverride>0</tx_realurl_pathoverride>
+		<tx_realurl_exclude>0</tx_realurl_exclude>
+	</pages>
+	<pages>
+		<uid>8</uid>
+		<pid>2</pid>
+		<doktype>1</doktype>
+		<deleted>0</deleted>
+		<title>subpage8</title>
+		<alias></alias>
+		<tx_realurl_pathsegment></tx_realurl_pathsegment>
+		<tx_realurl_pathoverride>0</tx_realurl_pathoverride>
+		<tx_realurl_exclude>0</tx_realurl_exclude>
+	</pages>
+	<pages>
+		<uid>9</uid>
+		<pid>2</pid>
+		<doktype>1</doktype>
+		<deleted>0</deleted>
+		<title>0</title>
+		<alias></alias>
+		<tx_realurl_pathsegment></tx_realurl_pathsegment>
+		<tx_realurl_pathoverride>0</tx_realurl_pathoverride>
+		<tx_realurl_exclude>0</tx_realurl_exclude>
+	</pages>
+</dataset>

--- a/Tests/Functional/Encoder/UrlEncoderTest.php
+++ b/Tests/Functional/Encoder/UrlEncoderTest.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace DmitryDulepov\Realurl\Tests\Functional\Encoder;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2016 Dmitry Dulepov (dmitry.dulepov@gmail.com)
+ *  (c) 2016 Robert Vock (robertvock82@gmail.com)
+ *  All rights reserved
+ *
+ *  You may not remove or change the name of the author above. See:
+ *  http://www.gnu.org/licenses/gpl-faq.html#IWantCredit
+ *
+ *  This script is part of the Typo3 project. The Typo3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *  A copy is found in the textfile GPL.txt and important notices to the license
+ *  from the author is found in LICENSE.txt distributed with these scripts.
+ *
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+
+use DmitryDulepov\Realurl\Configuration\ConfigurationReader;
+use DmitryDulepov\Realurl\Utility as RealurlUtility;
+use DmitryDulepov\Realurl\Encoder\UrlEncoder;
+
+/**
+ * Testcase for class \DmitryDulepov\Realurl\Encoder\UrlEncoder
+ */
+class UrlEncoderTest extends \TYPO3\CMS\Core\Tests\FunctionalTestCase {
+
+	/**
+	 * Set up tests
+	 */
+	protected function setUp() {
+		$this->testExtensionsToLoad[] = 'typo3conf/ext/realurl/';
+
+		parent::setUp();
+
+		$GLOBALS['LANG'] = GeneralUtility::makeInstance(\TYPO3\CMS\Lang\LanguageService::class);
+		$GLOBALS['LANG']->init('default');
+
+		$this->importDataSet(__DIR__ . '/../../Fixtures/realurl.xml');
+
+		$GLOBALS['TSFE'] = $this->getMock(TypoScriptFrontendController::class, array(), array(), '', false);
+		$GLOBALS['TSFE']->config = ['config' => ['tx_realurl_enable' => 1]];
+		$GLOBALS['TSFE']->id = 1;
+
+		$_SERVER['HTTP_HOST'] = 'www.example.com';
+
+		$GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['realurl'] = serialize([
+			'configFile' => 'typo3conf/realurl_conf.php',
+			'enableAutoConf' => 1,
+			'autoConfFormat' => 0,
+			'enableDevLog' => 0,
+		]);
+	}
+
+	protected function getParametersForPage($pageUid) {
+		// only totalURL is needed for tests
+		return [
+			'LD' => [
+				'totalURL' => 'index.php?id=' . $pageUid,
+			],
+			'args' => [], // ignored
+			'typeNum' => null,
+		];
+	}
+
+	/**
+	 * Tests encoding the home URL
+	 *
+	 * @test
+	 */
+	public function testEncodeHomeUrl() {
+		$parameters = $this->getParametersForPage(1);
+
+		$encoder = GeneralUtility::makeInstance(UrlEncoder::class);
+		$encoder->encodeUrl($parameters);
+		$this->assertNotNull($encoder->getConfiguration(), 'encoder configuration is null');
+		$this->assertEquals($encoder->getConfiguration()->get('init/emptyUrlReturnValue') ?: '/', $parameters['LD']['totalURL']);
+	}
+
+	/**
+	 * Tests encoding of a normal pages
+	 *
+	 * @test
+	 */
+	public function testEncodeNormalPages() {
+		// Normal page without child-pages
+		$parameters = $this->getParametersForPage(3);
+		$encoder = GeneralUtility::makeInstance(UrlEncoder::class);
+		$encoder->encodeUrl($parameters);
+		$this->assertEquals('page3/', $parameters['LD']['totalURL'], 'Normal page without child-pages');
+
+		// Normal page with child-pages
+		$parameters = $this->getParametersForPage(2);
+		$encoder = GeneralUtility::makeInstance(UrlEncoder::class);
+		$encoder->encodeUrl($parameters);
+		$this->assertEquals('page2/', $parameters['LD']['totalURL'], 'Normal page with child-pages');
+	}
+
+	/**
+	 * Tests encoding of a normal child-page
+	 *
+	 * @test
+	 */
+	public function testEncodeNormalChildPages() {
+		// Normal Child
+		$parameters = $this->getParametersForPage(8);
+		$encoder = GeneralUtility::makeInstance(UrlEncoder::class);
+		$encoder->encodeUrl($parameters);
+		$this->assertEquals('page2/subpage8/', $parameters['LD']['totalURL'], 'Normal Child');
+
+		// Child with tx_realurl_pathoverride
+		$parameters = $this->getParametersForPage(5);
+		$encoder = GeneralUtility::makeInstance(UrlEncoder::class);
+		$encoder->encodeUrl($parameters);
+		$this->assertEquals('page5-override/', $parameters['LD']['totalURL'], 'Child with tx_realurl_pathoverride');
+
+		// Child with alias
+		$parameters = $this->getParametersForPage(6);
+		$encoder = GeneralUtility::makeInstance(UrlEncoder::class);
+		$encoder->encodeUrl($parameters);
+		$this->assertEquals('page2/page6-alias/', $parameters['LD']['totalURL'], 'Child with alias');
+	}
+
+	/**
+	 * Tests encoding of a page with a parent with tx_realurl_exclude=1
+	 *
+	 * @test
+	 */
+	public function testEncodeExcludeFromUrl() {
+		// Page with tx_realurl_exclude=1 should appear in url, if it is the last segment
+		$parameters = $this->getParametersForPage(4);
+		$encoder = GeneralUtility::makeInstance(UrlEncoder::class);
+		$encoder->encodeUrl($parameters);
+		$this->assertEquals('page4/', $parameters['LD']['totalURL'], 'Page with tx_realurl_exclude=1');
+
+		// Child with a parent with tx_realurl_exclude=1
+		$parameters = $this->getParametersForPage(7);
+		$encoder = GeneralUtility::makeInstance(UrlEncoder::class);
+		$encoder->encodeUrl($parameters);
+		$this->assertEquals('subpage7-without-parent/', $parameters['LD']['totalURL'], 'Child with a parent with tx_realurl_exclude=1');
+	}
+
+	/**
+	 * Tests encoding of a page with "0" as title
+	 *
+	 * @test
+	 * @see https://github.com/dmitryd/typo3-realurl/issues/207
+	 */
+	public function testEncodePageTitle0() {
+		// Page with tx_realurl_exclude=1 should appear in url, if it is the last segment
+		$parameters = $this->getParametersForPage(9);
+		$encoder = GeneralUtility::makeInstance(UrlEncoder::class);
+		$encoder->encodeUrl($parameters);
+		$this->assertEquals('page2/0/', $parameters['LD']['totalURL'], 'Page with title="0" is not encoded correctly');
+	}
+}

--- a/Tests/Functional/UtilityTest.php
+++ b/Tests/Functional/UtilityTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace DmitryDulepov\Realurl\Tests\Functional;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2016 Dmitry Dulepov (dmitry.dulepov@gmail.com)
+ *  (c) 2016 Robert Vock (robertvock82@gmail.com)
+ *  All rights reserved
+ *
+ *  You may not remove or change the name of the author above. See:
+ *  http://www.gnu.org/licenses/gpl-faq.html#IWantCredit
+ *
+ *  This script is part of the Typo3 project. The Typo3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *  A copy is found in the textfile GPL.txt and important notices to the license
+ *  from the author is found in LICENSE.txt distributed with these scripts.
+ *
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+use DmitryDulepov\Realurl\Configuration\ConfigurationReader;
+use DmitryDulepov\Realurl\Utility as RealurlUtility;
+
+/**
+ * Testcase for class \DmitryDulepov\Realurl\Utility
+ */
+class UtilityTest extends \TYPO3\CMS\Core\Tests\FunctionalTestCase {
+
+	/** @var \DmitryDulepov\Realurl\Configuration\ConfigurationReader */
+	protected $configuration;
+
+	/** @var \DmitryDulepov\Realurl\Utility */
+	protected $utility;
+
+	/**
+	 * Set up tests
+	 */
+	protected function setUp() {
+		$this->testExtensionsToLoad[] = 'typo3conf/ext/realurl/';
+
+		parent::setUp();
+
+		$GLOBALS['LANG'] = GeneralUtility::makeInstance(\TYPO3\CMS\Lang\LanguageService::class);
+		$GLOBALS['LANG']->init('default');
+
+		$this->configuration = GeneralUtility::makeInstance(ConfigurationReader::class, ConfigurationReader::MODE_DECODE);
+		$this->utility = GeneralUtility::makeInstance(RealurlUtility::class, $this->configuration);
+	}
+
+	/**
+	 * Tests conversion of strings to safe url (without any special chars or whitespace)
+	 *
+	 * @test
+	 */
+	public function convertToSafeString() {
+		// umlauts should be converted
+		$this->assertEquals('umlauts-ae-ss-oe', $this->utility->convertToSafeString('umlauts ä ß Ö'), 'Umlauts should be converted');
+
+		// no special chars should appear in the final string (some will be replaced with more readable output)
+		$this->assertEquals('special-chars-eur-r-o-oe-p-aa-f-c-a-o-yen-c-u', $this->utility->convertToSafeString('special-chars-«-∑-€-®-†-Ω-¨-⁄-ø-π-å-‚-∂-ƒ-©-ª-º-∆-@-¥-≈-ç-√-∫-~-µ-∞-…-–'));
+	}
+
+	/**
+	 * Test if whitespace is trimmed and spaces are treated the same as tabs and nbsp
+	 *
+	 * @test
+	 * @see https://github.com/dmitryd/typo3-realurl/issues/218
+	 */
+	public function convertToSafeStringWithWhitespace() {
+		// the string should be trimmed
+		$this->assertEquals('trim', $this->utility->convertToSafeString("  trim  "));
+
+		// the next line contains a non-breaking-sapce (\x20)
+		$this->assertEquals('non-breaking-space-split', $this->utility->convertToSafeString("non-breaking-space split"), 'Non-breaking-spaces should be treated as whitespace');
+
+		// tabs should be treated the same as white-space
+		$this->assertEquals('tab-split', $this->utility->convertToSafeString("tab\tsplit"), 'tabs should be treated the same as white-space');
+	}
+}

--- a/Tests/Unit/RealurlTest.php
+++ b/Tests/Unit/RealurlTest.php
@@ -1,0 +1,17 @@
+<?php
+namespace DmitryDulepov\Realurl\Tests\Unit;
+
+class RealurlTest extends \TYPO3\CMS\Core\Tests\UnitTestCase {
+
+	public function setUp() {
+		parent::setUp();
+	}
+
+	/**
+	 * @test
+	 */
+	public function testCase() {
+		// write testcases here, which do not depend on a valid-typo3 system
+		$this->assertEquals('1', '1');
+	}
+}

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,11 @@
         "typo3-ter/realurl": "self.version"
     },
     "require": {
-        "typo3/cms-core": ">=6.2.0,<8.1.0",
+        "typo3/cms": ">=6.2.0,<8.1.0",
         "php": ">=5.3.2"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "~4.8.0"
     },
     "suggest": {
       "typo3-ter/static-info-tables": ">=6.2.0"
@@ -33,11 +36,34 @@
             "DmitryDulepov\\Realurl\\": "Classes"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "DmitryDulepov\\Realurl\\Tests\\": "Tests/",
+            "TYPO3\\CMS\\Core\\Tests\\": ".Build/vendor/typo3/cms/typo3/sysext/core/Tests/"
+        }
+    },
     "authors": [
         {
             "name": "Dmitry Dulepov",
             "email": "dmitry.dulepov@gmail.com",
             "homepage": "http://www.dmitry-dulepov.com/"
         }
-    ]
+    ],
+    "config": {
+        "vendor-dir": ".Build/vendor",
+        "bin-dir": ".Build/bin"
+    },
+    "scripts": {
+        "post-autoload-dump": [
+            "mkdir -p .Build/Web/typo3conf/ext/",
+            "[ -L .Build/Web/typo3conf/ext/realurl ] || ln -snvf ../../../../. .Build/Web/typo3conf/ext/realurl"
+        ],
+        "test": "export TYPO3_PATH_WEB=`pwd`/.Build/Web; export typo3DatabaseName='realurl'; export typo3DatabaseHost='127.0.0.1'; export typo3DatabaseUsername='realurl'; export typo3DatabasePassword=''; .Build/bin/phpunit --colors -c .Build/vendor/typo3/cms/typo3/sysext/core/Build/UnitTests.xml Tests/Unit/; .Build/bin/phpunit --colors -c .Build/vendor/typo3/cms/typo3/sysext/core/Build/FunctionalTests.xml Tests/Functional/"
+    },
+    "extra": {
+        "typo3/cms": {
+            "cms-package-dir": "{$vendor-dir}/typo3/cms",
+            "web-dir": ".Build/Web"
+        }
+    }
 }


### PR DESCRIPTION
I created some basic functional testcases for realurl. I've based the configuration for the tests on code from [extension_builder](https://github.com/TYPO3-extensions/extension_builder).

To run the test-cases, you need to install the dependencies using composer:
```
composer install --dev
```

Afterwards, you can run the tests using `composer test`. You need a database user `realurl` without a password to run the tests. Alternatively you can run the following commands:
```
export TYPO3_PATH_WEB=`pwd`/.Build/Web
export typo3DatabaseName='realurl'
export typo3DatabaseHost='127.0.0.1'
export typo3DatabaseUsername='realurl'
export typo3DatabasePassword=''
.Build/bin/phpunit --colors -c .Build/vendor/typo3/cms/typo3/sysext/core/Build/UnitTests.xml Tests/Unit/
.Build/bin/phpunit --colors -c .Build/vendor/typo3/cms/typo3/sysext/core/Build/FunctionalTests.xml Tests/Functional/
```

The tests generate a complete TYPO3 installation within the `.Build/Web` folder and creates test instances for each test-class in `.Build/Web/typo3temp/var/tests/`

Currently there are only some simple tests for URL encoding:
- normal pages and child pages
- configuration of tx_realurl_exclude, tx_realurl_pathoverride and alias

I also included tests for some of the latest bug reports:
- #218 
- #207 

In the future I would like to add tests for encoding more complicated URLs:
- various language configurations
- Parameters in the URL
- multiple domains

I also added a .gitattributes file to exclude the testcases from the zip-releases here on github. I do not know how the releases for TER are generated, but they also could exclude the tests. But they are not large so it shouldn't matter much.

Ping #8 