### PR TITLE
[BUGFIX] Overwrites autoconf file

### DIFF
--- a/class.tx_realurl_autoconfgen.php
+++ b/class.tx_realurl_autoconfgen.php
@@ -83,7 +83,7 @@ class tx_realurl_autoconfgen {
 		$fileName = PATH_site . TX_REALURL_AUTOCONF_FILE;
 
 		$lockObject = $this->apiWrapper->getLockObject($fileName);
-		$fd = @fopen($fileName, 'a+');
+		$fd = @fopen($fileName, 'w+');
 		if ($fd) {
 			// Check size
 			fseek($fd, 0, SEEK_END);


### PR DESCRIPTION
In a situation where the autoconf file could not be deleted due to a change in sys_domain table, the autoconf will be appended to the file.
This result will lead to a 500 page.