### PR TITLE
[BUGFIX] preVars valueDefault has wrong behavior

### DIFF
--- a/Classes/Encoder/UrlEncoder.php
+++ b/Classes/Encoder/UrlEncoder.php
@@ -545,7 +545,7 @@ class UrlEncoder extends EncodeDecoderBase {
 	protected function encodePreVars() {
 		$preVars = (array)$this->configuration->get('preVars');
 		if (count($preVars) > 0) {
-			$segments = $this->encodeUrlParameterBlock($preVars);
+			$segments = $this->encodeUrlParameterBlock($preVars, true);
 			if (count($segments) > 0) {
 				$this->appendToEncodedUrl(implode('/', $segments));
 			}
@@ -621,12 +621,13 @@ class UrlEncoder extends EncodeDecoderBase {
 	 * Encodes pre- or postVars according to the given configuration.
 	 *
 	 * @param array $configurationArray
+     * @param bool $noCheck
 	 * @return string
 	 */
-	protected function encodeUrlParameterBlock(array $configurationArray) {
+	protected function encodeUrlParameterBlock(array $configurationArray, $noCheck = false) {
 		$segments = array();
 
-		if ($this->hasUrlParameters($configurationArray)) {
+		if ($noCheck || $this->hasUrlParameters($configurationArray)) {
 			$previousValue = '';
 			foreach ($configurationArray as $configuration) {
 				// Technically it must always be array!


### PR DESCRIPTION
In realurl version 1.x a defined "valueDefault" was added to the uri, when the urlParameter didn't exists.
Since version 2.x the valueDefault is ignored.

```php
'preVars' => array(
    array(
        'GETvar' => 'L',
        'valueMap' => array(
            'de' => 0,
            'fr' => 1,
        ),
        'valueDefault' => 'de',
    ),
),
```

Example: urlParameter L is not set.

in Version 1.x the 'valueDefault' was added to the url: ```http://www.domain.com/de/pagename```
since version 2 the 'valueDefault' is ignored: ```http://www.domain.com/pagename```
