### PR TITLE
[TASK] In case of duplicated urldata entries, prefer those with cHash

### DIFF
--- a/Classes/Cache/DatabaseCache.php
+++ b/Classes/Cache/DatabaseCache.php
@@ -199,6 +199,15 @@ class DatabaseCache implements CacheInterface, SingletonInterface {
 				'', 'expire'
 		);
 
+		// More than one urldata entry? Then prefer those with cHash
+		if (count($rows) > 1) {
+			if (preg_match('/cHash/', json_encode($rows))) {
+				$rows = array_filter($rows, function ($row) {
+					return strpos($row['original_url'], 'cHash') !== false ? true : false;
+				});
+			}
+		}
+
 		$row = null;
 		foreach ($rows as $rowCandidate) {
 			if (is_null($languageId)) {


### PR DESCRIPTION
It could happen that RealUrl encodes more than one urldata entry for the same speaking url. Usually one of the entries does have cHash and the other does not. This commit makes sure that, in this case, the entry with the cHash is taken into account over the one without.