### PR TITLE
[TASK] Store crdate when a new record is created in tx_realurl_urldata

### DIFF
--- a/Classes/Cache/DatabaseCache.php
+++ b/Classes/Cache/DatabaseCache.php
@@ -369,6 +369,8 @@ class DatabaseCache implements CacheInterface, SingletonInterface {
 			if ($this->limitTableRecords('tx_realurl_urldata')) {
 				$this->databaseConnection->sql_query('DELETE FROM tx_realurl_uniqalias_cache_map WHERE url_cache_id NOT IN (SELECT uid FROM tx_realurl_urldata)');
 			}
+
+			$data['crdate'] = time();
 			$this->databaseConnection->exec_INSERTquery('tx_realurl_urldata', $data);
 			$cacheEntry->setCacheId($this->databaseConnection->sql_insert_id());
 


### PR DESCRIPTION
I don't know if there's a particular reason why crdate is not stored since there is the field in the DB.
I think that crdate is very useful when trying to understand what created a particular entry while debugging Realurl configuration. With crdate you can, by example, go back to the HTTP request from the Apache log.