### PR TITLE
#295 - RealUrl will now only store INT values for "L" parameter to tx…

### DIFF
--- a/Classes/Cache/DatabaseCache.php
+++ b/Classes/Cache/DatabaseCache.php
@@ -137,6 +137,7 @@ class DatabaseCache implements CacheInterface, SingletonInterface {
 			foreach ($rows as $row) {
 				$requestVariables = @json_decode($row['request_variables'], TRUE);
 				if (is_array($requestVariables) && (int)$requestVariables['L'] === (int)$languageId) {
+					$requestVariables['L'] = (int)$requestVariables['L'] ;
 					$this->databaseConnection->exec_UPDATEquery('tx_realurl_urldata',
 						'uid=' . (int)$row['uid'], array('expire' => $expirationTime)
 					);

--- a/Classes/Decoder/UrlDecoder.php
+++ b/Classes/Decoder/UrlDecoder.php
@@ -579,7 +579,8 @@ class UrlDecoder extends EncodeDecoderBase implements SingletonInterface {
 			}
 
 			if (isset($requestVariables['L'])) {
-				$this->detectedLanguageId = (int)$requestVariables['L'];
+				$requestVariables['L'] = (int)$requestVariables['L'] ;
+				$this->detectedLanguageId = $requestVariables['L'];
 			}
 		}
 		if (is_null($this->detectedLanguageId)) {


### PR DESCRIPTION
…_realurl_urldata Table

before storing/detecting the requestVariables param L= cast the Value to INT to AVOID that params like L=1'A=0   will reach the tx_realurl_urldata table and show wrong language output in Frontend