### PR TITLE
[FEATURE] add keepParameter option for domains

### DIFF
--- a/Classes/Encoder/UrlEncoder.php
+++ b/Classes/Encoder/UrlEncoder.php
@@ -1171,7 +1171,10 @@ class UrlEncoder extends EncodeDecoderBase {
 					// because 'urlPrepend' is typically used for language-based domains.
 					// But 'useConfiguration' can be used to localize postVarSet segment
 					// values. So we change the behavior here comparing to 1.x.
-					unset($this->urlParameters[$getVarName]);
+					// But you can prevent realurl from removing the var by using the keepParameter option
+					if (!isset($configuration['keepParameter']) && $configuration['keepParameter']) {
+						unset($this->urlParameters[$getVarName]);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
if you are using 2 domains for 3 languages, you need to have the L parameter present for the pagepath. Now you have a keepParameter option for the _DOMAINS configuration, to prevent realurl from unsetting the lang param.

Example:

foobar.de/de/
foobar.de/en/
foobar.es

If you configure the _DOMAINS you loose the language param for page path decoding. To prevent this and leave the API backwards compatible, I've introduced a new option for the _DOMAINS section.