### PR TITLE
add 2nd index to tx_realurl_uniqalias_cache_map

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -26,7 +26,8 @@ CREATE TABLE tx_realurl_uniqalias_cache_map (
 	alias_uid int(11) DEFAULT '0' NOT NULL,
 	url_cache_id int(11) DEFAULT '0' NOT NULL,
 
-	KEY check_existence (alias_uid,url_cache_id)
+	KEY check_existence (alias_uid,url_cache_id),
+	KEY url_cache_id (url_cache_id)
 ) ENGINE=InnoDB;
 
 #


### PR DESCRIPTION
add index on url_cache_id  to tx_realurl_uniqalias_cache_map to speedup deletes.
the combined index check_existence is not used in queries like
DELETE FROM tx_realurl_uniqalias_cache_map WHERE url_cache_id = XXXX .
