### PR TITLE
added option to deactivate urlcache on single pages

### DIFF
--- a/Classes/Encoder/UrlEncoder.php
+++ b/Classes/Encoder/UrlEncoder.php
@@ -1276,7 +1276,16 @@ class UrlEncoder extends EncodeDecoderBase {
 	 * @return void
 	 */
 	protected function storeInUrlCache() {
-		if ($this->canCacheUrl($this->originalUrl)) {
+
+                $cacheDeactivated = $this->databaseConnection->exec_SELECTgetRows(
+                        'tx_realurl_nocache',
+                        'pages',
+                        'uid = ' . $this->urlParameters['id'],
+                        '',
+                        '',
+                        '')[0]['tx_realurl_nocache'];
+
+		if ($this->canCacheUrl($this->originalUrl)  && !$cacheDeactivated) {
 			$cacheEntry = $this->cache->getUrlFromCacheByOriginalUrl($this->rootPageId, $this->originalUrl);
 			/** @var \DmitryDulepov\Realurl\Cache\UrlCacheEntry $cacheEntry */
 			if ($cacheEntry && $cacheEntry->getExpiration() !== 0 && $cacheEntry->getSpeakingUrl() === $this->encodedUrl) {

--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -51,7 +51,7 @@ if (!isset($GLOBALS['TCA']['pages']['columns']['tx_realurl_pathsegment'])) {
 	\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('pages', '--palette--;LLL:EXT:realurl/Resources/Private/Language/locallang_db.xlf:pages.palette_title;tx_realurl', '4,199,254', 'after:title');
 
 	$GLOBALS['TCA']['pages']['palettes']['tx_realurl'] = array(
-		'showitem' => 'tx_realurl_pathsegment,--linebreak--,tx_realurl_exclude,tx_realurl_pathoverride'
+		'showitem' => 'tx_realurl_pathsegment,--linebreak--,tx_realurl_exclude,tx_realurl_pathoverride,tx_realurl_nocache'
 	);
 
 }


### PR DESCRIPTION
In situations where a misconfigured system or plugins excessively using get parameters may pollute the url cache (even to a failing state), deactivating the url cache for single pages may be a work around or even a solution (for example large formhandler formulars).
These additions put the "deactivate realurl cache" option back into the pages' properties section and respect this option on creating a new url cache entry.