### PR TITLE
[BUGFIX] ensure removeIgnoredParametersFromQueryString returns string

### DIFF
--- a/Classes/EncodeDecoderBase.php
+++ b/Classes/EncodeDecoderBase.php
@@ -251,6 +251,8 @@ abstract class EncodeDecoderBase {
 				}
 				$queryString = $this->createQueryStringFromParameters($collectedParameters);
 			}
+		} else {
+			$queryString = '';
 		}
 
 		return $queryString;


### PR DESCRIPTION
If the url has no query string, removeIgnoredParametersFromURL sets
the variable to null. This causes, that the function
removeIgnoredParametersFromQueryString returns null as well. But if
it returns null instead of empty string, the
removeIgnoredParametersFromURL function appends an senseless
question mark.