### PR TITLE
[BUGFIX] Dynamic Asset Path for Backend Module

### DIFF
--- a/Resources/Private/Layouts/Backend.html
+++ b/Resources/Private/Layouts/Backend.html
@@ -2,9 +2,9 @@
 
 <f:be.container>
 	<f:be.pageRenderer includeCssFiles="{
-		1: '../typo3conf/ext/realurl/Resources/Public/realurl_be.css'
+		1: '{f:uri.resource(path:\'realurl_be.css\')}'
 	}" includeJsFiles="{
-		2: '../typo3conf/ext/realurl/Resources/Public/realurl_be.js'
+		2: '{f:uri.resource(path:\'realurl_be.js\')}'
 	}" loadJQuery="1"/>
 	<div class="typo3-fullDoc">
 		<div id="typo3-docheader">


### PR DESCRIPTION
We install the extension with composer into the typo3/ext folder. Because the path to the assets were hard coded (typo3conf/ext) the assets could not be loaded. With this fix, the path gets generated correct irrespective of the extension installation path.