### PR TITLE
[TASK] reduce amount of calls to limit entries in database tables

### DIFF
--- a/Classes/Cache/DatabaseCache.php
+++ b/Classes/Cache/DatabaseCache.php
@@ -406,7 +406,7 @@ class DatabaseCache implements CacheInterface, SingletonInterface {
 	 */
 	protected function limitTableRecords($tableName) {
 		$cleanedUp = false;
-		if ((mt_rand(0, mt_getrandmax()) % 5) == 0) {
+		if ((mt_rand(0, mt_getrandmax()) % 5000) == 0) {
 			$this->databaseConnection->sql_query('DELETE FROM ' . $tableName .
 				' WHERE uid <= (SELECT t2.uid FROM (SELECT uid FROM ' .
 				$tableName .


### PR DESCRIPTION
on bigger websites (in our case ~50.000 pages and ~1.000 editors) the sql-statement to limit the number of entries in i.e. pathdata is called every few seconds. Because % 5 means around every fifth's time a new entry is written into that table. From my point of view it would be fitting to do this far more rarely.
It helped in our case to considerably improve DB performance.
% 5000 ist just a suggestion we use currently. Feel free to modify according to your opinion on that.