### PR TITLE
[TASK] Replace underscore with hyphen while saving explicit pathdata in backend

### DIFF
--- a/Classes/Evaluator/SegmentFieldCleaner.php
+++ b/Classes/Evaluator/SegmentFieldCleaner.php
@@ -38,6 +38,7 @@ class SegmentFieldCleaner {
 	 * @return string
 	 */
 	public function evaluateFieldValue($value) {
+        $value = str_replace('_', '-', $value);
 		return trim($value, '/');
 	}
 


### PR DESCRIPTION
this is meant as hint to a behaviour which is confusing our editors currently. If the fill the pathdata-field explicitely they expect the url to be exactly like what they entered. Since in former realurl-version they used the underscore quite often, they still enter underscores. The underscore stays there if they save the page, but in frontend realurl creates a hyphen instead.
We are totally fine with the hyphens but suggest to replace underscores with hpyhens already while saving to avoid confusion.


