### PR TITLE
[TASK] fix urladata cache query

### DIFF
--- a/Classes/Decoder/UrlDecoder.php
+++ b/Classes/Decoder/UrlDecoder.php
@@ -1268,7 +1268,7 @@ class UrlDecoder extends EncodeDecoderBase implements SingletonInterface {
 	protected function runDecoding() {
 		$urlPath = $this->getUrlPath();
 
-		$cacheEntry = $this->getFromUrlCache($this->speakingUri);
+		$cacheEntry = $this->getFromUrlCache($urlPath);
 		if (!$cacheEntry) {
 			$this->originalPath = $urlPath;
 			$cacheEntry = $this->doDecoding($urlPath);


### PR DESCRIPTION
The urldata cacha is stored without leading slash
but was search with leading slash. The var $urlPath
contains the path without leading slash. Now cache
entries are found.