### PR TITLE
[BUGFIX] fix urldata cache entries

### DIFF
--- a/Classes/Cache/DatabaseCache.php
+++ b/Classes/Cache/DatabaseCache.php
@@ -361,7 +361,7 @@ class DatabaseCache implements CacheInterface, SingletonInterface {
 			'page_id' => $cacheEntry->getPageId(),
 			'request_variables' => json_encode($requestVariables),
 			'rootpage_id' => $cacheEntry->getRootPageId(),
-			'speaking_url' => $cacheEntry->getSpeakingUrl(),
+			'speaking_url' => $this->prepareCacheUri($cacheEntry->getSpeakingUrl()),
 		);
 		if ($cacheEntry->getCacheId()) {
 			$this->databaseConnection->exec_UPDATEquery('tx_realurl_urldata',
@@ -393,6 +393,23 @@ class DatabaseCache implements CacheInterface, SingletonInterface {
 
 			$this->databaseConnection->sql_query('COMMIT');
 		}
+	}
+
+	/**
+	 * Prepares the url to be stored in cache table.
+	 *  - Add leading slash
+	 *  - do urldecode
+	 *
+	 * @param string $uri
+	 *
+	 * @return string
+	 */
+	protected function prepareCacheUri($uri) {
+		if (substr($uri,0,1) !== '/' && substr($uri,0,1) !== '?') {
+			$uri = '/' . $uri;
+		}
+		$uri = urldecode($uri);
+		return $uri;
 	}
 
 	/**

--- a/Classes/Decoder/UrlDecoder.php
+++ b/Classes/Decoder/UrlDecoder.php
@@ -1268,7 +1268,7 @@ class UrlDecoder extends EncodeDecoderBase implements SingletonInterface {
 	protected function runDecoding() {
 		$urlPath = $this->getUrlPath();
 
-		$cacheEntry = $this->getFromUrlCache($this->speakingUri);
+		$cacheEntry = $this->getFromUrlCache(urldecode($this->speakingUri));
 		if (!$cacheEntry) {
 			$this->originalPath = $urlPath;
 			$cacheEntry = $this->doDecoding($urlPath);


### PR DESCRIPTION
Store the url in urldata cache in such way
to be found with $this-speakingUri in decode
process.

* add leading slash
* do urldecode

The cache entries are not found because of these two points above.