### PR TITLE
[BUGFIX] use mb_substr for alias

### DIFF
--- a/Classes/Encoder/UrlEncoder.php
+++ b/Classes/Encoder/UrlEncoder.php
@@ -388,7 +388,7 @@ class UrlEncoder extends EncodeDecoderBase {
 				}
 
 				$maxAliasLengthLength = isset($configuration['maxLength']) ? (int)$configuration['maxLength'] : self::MAX_ALIAS_LENGTH;
-				$aliasValue = substr($row[$configuration['alias_field']], 0, $maxAliasLengthLength);
+				$aliasValue = mb_substr($row[$configuration['alias_field']], 0, $maxAliasLengthLength);
 
 				# Do not allow aliases to be empty (see issue #1)
 				if (empty($aliasValue)) {


### PR DESCRIPTION
Since substr ist not multi-byte save, realurl cannot create an alias if you have for example a news title with a german umlaut at exactly the position where you want to cut the string. Then the alias ist just empty.
Using mb_substr fixes that issue.