### PR TITLE
[BUGFIX] Cover all cases for appendMissingSlash

### DIFF
--- a/Classes/Decoder/UrlDecoder.php
+++ b/Classes/Decoder/UrlDecoder.php
@@ -234,8 +234,8 @@ class UrlDecoder extends EncodeDecoderBase implements SingletonInterface {
 			if ($this->appendedSlash && count($options) > 0) {
 				foreach ($options as $option) {
 					$matches = array();
-					if (preg_match('/^ifNotFile|redirect(\[(30[1237])\])?$/', $option, $matches)) {
-						$code = count($matches) > 1 ? $matches[2] : 301;
+					if (preg_match('/^(ifNotFile|redirect(\[(30[1237])\])?)$/', $option, $matches)) {
+						$code = count($matches) > 2 ? $matches[3] : 301;
 						$status = 'HTTP/1.1 ' . $code . ' TYPO3 RealURL redirect';
 
 						// Check path segment to be relative for the current site.

--- a/Classes/Decoder/UrlDecoder.php
+++ b/Classes/Decoder/UrlDecoder.php
@@ -234,7 +234,7 @@ class UrlDecoder extends EncodeDecoderBase implements SingletonInterface {
 			if ($this->appendedSlash && count($options) > 0) {
 				foreach ($options as $option) {
 					$matches = array();
-					if (preg_match('/^redirect(\[(30[1237])\])?$/', $option, $matches)) {
+					if (preg_match('/^ifNotFile|redirect(\[(30[1237])\])?$/', $option, $matches)) {
 						$code = count($matches) > 1 ? $matches[2] : 301;
 						$status = 'HTTP/1.1 ' . $code . ' TYPO3 RealURL redirect';
 


### PR DESCRIPTION
Add `ifNotFile` in the regex to also match that option

I have a Multi language (`DE, EN, ES`) TYPO3 installation with realurl installed and configured. Default language `DE`
When I request `domain.com/es/` I get the Spanish version
But when I request `domain.com/es` without slash at end, I get German version.

This fix solves my problem.