### PR TITLE
[BUGFIX][1.x] Always include id in parameters for cHash when decoding SpUrl

### DIFF
--- a/class.tx_realurl.php
+++ b/class.tx_realurl.php
@@ -1190,7 +1190,13 @@ class tx_realurl extends tx_realurl_baseclass {
 
 		// cHash handling
 		if ($cHashCache) {
+
+			if($GLOBALS['TYPO3_CONF_VARS']['FE']['cHashIncludePageId'] && !$cachedInfo['GET_VARS']['id']) {
+				$cachedInfo['GET_VARS']['id'] = $cachedInfo['id'];
+			}
+
 			$queryString = $this->apiWrapper->implodeArrayForUrl('', $cachedInfo['GET_VARS']);
+
 			$containsRelevantParametersForCHashCreation = count($this->apiWrapper->getRelevantChashParameters($queryString)) > 0;
 
 			if ($containsRelevantParametersForCHashCreation) {


### PR DESCRIPTION
When using e.g. tt_news, seemingly proper speaking URLs were created,
but when opening a news item link, the \RuntimeException('ID parameter
needs to be passed for the cHash calculation! As a temporary not
recommended workaround, you can set
$GLOBALS[\'TYPO3_CONF_VARS\'][\'FE\'][\'cHashIncludePageId\'] to false
to avoid this error.', 1467983513); would occur.

Now, a known id as returned by \tx_realurl::decodeSpURL_idFromPath()
(into $cachedInfo['id']) will be added to $cachedInfo['GET_VARS'] for
the $queryString passed to
\tx_realurl_apiwrapper::getRelevantChashParameters().