### PR TITLE
[BUGFIX] rawurlencode query string parameters in tx_realurl_urldata

### DIFF
--- a/Classes/EncodeDecoderBase.php
+++ b/Classes/EncodeDecoderBase.php
@@ -98,10 +98,11 @@ abstract class EncodeDecoderBase {
 	 * parameters.
 	 *
 	 * @param array $parameters
+	 * @param bool  $rawurlencodeParamName
 	 * @return mixed
 	 */
-	protected function createQueryStringFromParameters(array $parameters) {
-		return substr(GeneralUtility::implodeArrayForUrl('', $parameters), 1);
+	protected function createQueryStringFromParameters(array $parameters, $rawurlencodeParamName = true) {
+		return substr(GeneralUtility::implodeArrayForUrl('', $parameters, '', false, $rawurlencodeParamName), 1);
 	}
 
 	/**


### PR DESCRIPTION
Currently `speaking_url` and `original_url` are stored unencoded in
tx_realurl_urldata. When looking up a cache entry for
the current request $TSFE->siteScript is effectively compared with
`speaking_url`. The former is url encoded, the latter not.
Thus a cache entry will never be found if the url contains characters
that need encoding (like square bracket).

This will break in the following case:
If no cache entry was found, a temporary cacheEntry was created which
did not blow up unless one used fixedPostVars, additionalGetParams (e.g GETvars
not mentioned in fixedPostVars and thus appended to the url), and
noMatch=bypass (to remove some GETvars, e.g tx_foo_bar[action])
and a cHash.
realurl tries to recreate the parameters as temporary cacheEntry
from the url, but it doesn't know the GETvar value used for the
noMatch=bypass rule, so that GETvar will be missing and the cHash
comparision will fail.