### PR TITLE
Crossdomain links when rootpage_id is not defined

### DIFF
--- a/Classes/Configuration/ConfigurationReader.php
+++ b/Classes/Configuration/ConfigurationReader.php
@@ -435,6 +435,9 @@ class ConfigurationReader {
 					}
 				}
 			}
+			if (empty($this->hostName)) {
+				$this->hostName = $GLOBALS['TSFE']->getDomainNameForPid($id);
+			}
 		}
 		if (empty($this->hostName)) {
 			$this->alternativeHostName = $this->hostName = $this->utility->getCurrentHost();
@@ -465,7 +468,7 @@ class ConfigurationReader {
 		$result = FALSE;
 
 		// TODO Consider using PageRepository::getDomainStartPage()
-		$domainRecord = BackendUtility::getDomainStartPage($this->utility->getCurrentHost());
+		$domainRecord = BackendUtility::getDomainStartPage($this->hostName);
 		if (is_array($domainRecord)) {
 			$this->configuration['pagePath']['rootpage_id'] = (int)$domainRecord['pid'];
 			$result = TRUE;


### PR DESCRIPTION
The documentation says we are not forced to set the rootpage_id in
realurl_conf.php, but can use instead the domain records in typo3 as an
alternative.

However, cross domain links (with typolinkEnableLinksAcrossDomains
enabled) currently work only if each domain has been configured in
realurl_conf.php, with their rootpage_id defined. If using a [_DEFAULT]
config for all domains, cross domain links do not work properly as the
hostname cannot be determined by the setHostnamesForEncoding function.
And then, setRootPageIdFromDomainRecord tries to locate the sys_domain
record, but using the current hostname, not the targeted domain.