### PR TITLE
[BUGFIX] Mountpoints, crossdomain links and rootpage_id not set

### DIFF
--- a/Classes/Configuration/ConfigurationReader.php
+++ b/Classes/Configuration/ConfigurationReader.php
@@ -439,7 +439,7 @@ class ConfigurationReader {
 					}
 				}
 			}
-			if (empty($this->hostName)) {
+			if (empty($this->hostName) && !$MP) {
 				$this->hostName = $this->tsfe->getDomainNameForPid($id);
 			}
 		}


### PR DESCRIPTION
This fixes a bad side effect of the recent commit https://github.com/adrienjacob/typo3-realurl/commit/e1c847d1ef02fcf6ee7f0844cf3c743897423334: pages with mountpoint parameters no longer work in case rootpage_id is not configured, because getDomainNameForPid doesn't take MP params into account. Sorry for not noticing it earlier !

The suggested fix solves this, while still keeping the proper behaviour of cross domain links. However, I wonder whether the whole part here https://github.com/dmitryd/typo3-realurl/blob/development/Classes/Configuration/ConfigurationReader.php#L421-L445 should rather be skipped in case mountpoint params are set, as it's supposed to use only the current domain in this case ?