### PR TITLE
[FEATURE] Disable realurl encoding with TSFE register

### DIFF
--- a/Classes/Encoder/UrlEncoder.php
+++ b/Classes/Encoder/UrlEncoder.php
@@ -1105,7 +1105,8 @@ class UrlEncoder extends EncodeDecoderBase {
 	 * @return bool
 	 */
 	protected function isRealURLEnabled() {
-		return (bool)$this->tsfe->config['config']['tx_realurl_enable'];
+		return (bool)$this->tsfe->config['config']['tx_realurl_enable']
+			&& empty($this->tsfe->register['tx_realurl_disable']);
 	}
 
 	/**

--- a/Tests/Functional/Encoder/UrlEncoderTest.php
+++ b/Tests/Functional/Encoder/UrlEncoderTest.php
@@ -183,7 +183,7 @@ class UrlEncoderTest extends \TYPO3\CMS\Core\Tests\FunctionalTestCase {
 		$parameters = $this->getParametersForPage(2);
 		$encoder = GeneralUtility::makeInstance('DmitryDulepov\Realurl\Encoder\UrlEncoder');
 		$encoder->encodeUrl($parameters);
-		$this->assertEquals('index.php?id=2', $parameters['LD']['totalURL'], 'Normal page with child-pages');
+		$this->assertEquals('index.php?id=2', $parameters['LD']['totalURL'], 'tx_realurl_disable TSFE register does not disable encoding');
 	}
 
 	/**

--- a/Tests/Functional/Encoder/UrlEncoderTest.php
+++ b/Tests/Functional/Encoder/UrlEncoderTest.php
@@ -172,4 +172,24 @@ class UrlEncoderTest extends \TYPO3\CMS\Core\Tests\FunctionalTestCase {
 		$encoder->encodeUrl($parameters);
 		$this->assertEquals('page2/0/', $parameters['LD']['totalURL'], 'Page with title="0" is not encoded correctly');
 	}
+
+	/**
+	 * Tests if the register tx_realurl_disable disables URL encoding.
+	 *
+	 * @test
+	 */
+	public function testRegisterDisablesEncoding() {
+		$this->getTypoScriptFrontendController()->register['tx_realurl_disable'] = true;
+		$parameters = $this->getParametersForPage(2);
+		$encoder = GeneralUtility::makeInstance('DmitryDulepov\Realurl\Encoder\UrlEncoder');
+		$encoder->encodeUrl($parameters);
+		$this->assertEquals('index.php?id=2', $parameters['LD']['totalURL'], 'Normal page with child-pages');
+	}
+
+	/**
+	 * @return TypoScriptFrontendController
+	 */
+	protected function getTypoScriptFrontendController() {
+		return $GLOBALS['TSFE'];
+	}
 }


### PR DESCRIPTION
Encoding of URLs can now be temporarily disabled by setting
a boolean true value to the tx_realurl_disable register.

This can be used for creating a permalink for example:

```
10 = COA
10 {
	10 = LOAD_REGISTER
	10.tx_realurl_disable = 1

	20 = TEXT
	20.value = Permalink
	20.typolink {
		parameter.field = uid
		forceAbsoluteUrl = 1
	}

	30 = RESTORE_REGISTER
}
```