### PR TITLE
Do not force $this->tsfe->absRefPrefix in postProcessEncodedUrl

### DIFF
--- a/Classes/Encoder/UrlEncoder.php
+++ b/Classes/Encoder/UrlEncoder.php
@@ -147,7 +147,7 @@ class UrlEncoder extends EncodeDecoderBase {
 			// current host always. See http://bugs.typo3.org/view.php?id=18200
 			$testUrl = $parameters['finalTagParts']['url'];
 			if (preg_match('/^https?:\/\/[^\/]+\//', $testUrl)) {
-				$testUrl = preg_replace('/https?:\/\/[^\/]+\/(.*)$/', $this->tsfe->absRefPrefix . '\1', $testUrl);
+				$testUrl = preg_replace('/https?:\/\/[^\/]+\/(.*)$/', '\1', $testUrl);
 			}
 
 			list($testUrl, $section) = GeneralUtility::revExplode('#', $testUrl, 2);


### PR DESCRIPTION
Perhaps i do not get every possible scenario here, but in one scenario this method does not work correctly.

If you have www.domain.de (german) and de.domain.com (english) in one page tree and www.domain.ch (german) and ch.domain.com (english) in another page tree, it is not possible to link from de.domain.com to ch.domain.com. The Link on de.domain.com will always be www.domain.ch, if www.domain.ch is the first domain record in the page tree. 

Because of $this->tsfe->absRefPrefix the urlPrependRegister never gets used an so it can never set the right domain.

Not using absRefPrefix at all is no solution, because it is needed in my scenario. 

As i understand it, the urlPrependRegister is always right, so why bypass it with $this->tsfe->absRefPrefix?
If we just delete it form the url, the urlPrependRegister works as aspected.