### PR TITLE
[FEATURE] Configurable page title field list like "segTitleFieldList"

### DIFF
--- a/Classes/Decoder/UrlDecoder.php
+++ b/Classes/Decoder/UrlDecoder.php
@@ -340,7 +340,7 @@ class UrlDecoder extends EncodeDecoderBase implements SingletonInterface {
 			if ($this->detectedLanguageId > 0 && !isset($page['_PAGES_OVERLAY']) && (empty($languageExceptionUids) || !GeneralUtility::inList($languageExceptionUids, $this->detectedLanguageId))) {
 				$page = $this->pageRepository->getPageOverlay($page, (int)$this->detectedLanguageId);
 			}
-			foreach (self::$pageTitleFields as $field) {
+			foreach (self::getPageTitleFields() as $field) {
 				if (isset($page[$field]) && $page[$field] !== '' && $this->utility->convertToSafeString($page[$field], $this->separatorCharacter) === $segment) {
 					$result = GeneralUtility::makeInstance('DmitryDulepov\\Realurl\\Cache\\PathCacheEntry');
 					/** @var \DmitryDulepov\Realurl\Cache\PathCacheEntry $result */

--- a/Classes/EncodeDecoderBase.php
+++ b/Classes/EncodeDecoderBase.php
@@ -61,9 +61,6 @@ abstract class EncodeDecoderBase {
 	/** @var PageRepository */
 	protected $pageRepository = NULL;
 
-	/** @var array */
-	static public $pageTitleFields = array('tx_realurl_pathsegment', 'alias', 'nav_title', 'title', 'uid');
-
 	/** @var int */
 	protected $rootPageId;
 
@@ -195,7 +192,17 @@ abstract class EncodeDecoderBase {
 		$this->separatorCharacter = $this->configuration->get('pagePath/spaceCharacter');
 	}
 
-	/**
+    /**
+     * Gets page title fields from ext conf or default
+     *
+     * @return array
+     */
+    public static function getPageTitleFields() {
+        $configuration = @unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['realurl']);
+        return !empty($configuration['segTitleFieldList']) ? GeneralUtility::trimExplode(',', $configuration['segTitleFieldList']) : array('tx_realurl_pathsegment', 'alias', 'nav_title', 'title', 'uid');
+    }
+
+    /**
 	 * Checks if system runs in non-live workspace
 	 *
 	 * @return boolean

--- a/Classes/Encoder/UrlEncoder.php
+++ b/Classes/Encoder/UrlEncoder.php
@@ -547,7 +547,7 @@ class UrlEncoder extends EncodeDecoderBase {
 				continue;
 			}
 
-			foreach (self::$pageTitleFields as $field) {
+			foreach (self::getPageTitleFields() as $field) {
 				if (isset($page[$field]) && $page[$field] !== '') {
 					$segment = $this->utility->convertToSafeString($page[$field], $this->separatorCharacter);
 					if ($segment === '') {

--- a/Classes/Hooks/DataHandler.php
+++ b/Classes/Hooks/DataHandler.php
@@ -212,7 +212,7 @@ class DataHandler implements SingletonInterface {
 					}
 				}
 			} else {
-				foreach (EncodeDecoderBase::$pageTitleFields as $fieldName) {
+				foreach (EncodeDecoderBase::getPageTitleFields() as $fieldName) {
 					if (isset($databaseData[$fieldName])) {
 						$expireCache = TRUE;
 						break;

--- a/Tests/Functional/Encoder/UrlEncoderTest.php
+++ b/Tests/Functional/Encoder/UrlEncoderTest.php
@@ -68,6 +68,7 @@ class UrlEncoderTest extends \TYPO3\CMS\Core\Tests\FunctionalTestCase {
 			'enableAutoConf' => 1,
 			'autoConfFormat' => 0,
 			'enableDevLog' => 0,
+            'segTitleFieldList' => ''
 		]);
 	}
 

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -7,6 +7,9 @@ enableAutoConf = 1
 # cat=basic/enable; type=options[Serialized=0,PHP source (slow!)=1]; label=Automatic configuration file format:Defines how autoconfiguration file is stored. Use "Serialized" because it is 10 times or more faster! Use "PHP source" if you are curious what is generated or want to copy and modify generated configuration.
 autoConfFormat = 0
 
+# cat=basic/enable; type=string; label=Order of page fields lookup for segment construction (old segTitleFieldList): Defaults to "tx_realurl_pathsegment, alias, nav_title, title, uid" if not set.
+segTitleFieldList =
+
 # cat=basic/enable; type=boolean; label=Enable devLog:Debugging-only! Required any 3rd party devLog extension
 enableDevLog = 0
 


### PR DESCRIPTION
Hi Dmitry,
this might be a solution to https://github.com/dmitryd/typo3-realurl/issues/199 . The hard coded property `pageTitleFields` is replaced by a configurable list via extension configuration.
If the list is not set, the dafault one will be used.
A new public static method gives access to this list and is also used in the DataHandler hook.
Maybe you find the time for having a look into it ;)