### PR TITLE
[TASK] Trim multiple slashes for URLs with additional params

### DIFF
--- a/Classes/Encoder/UrlEncoder.php
+++ b/Classes/Encoder/UrlEncoder.php
@@ -883,8 +883,8 @@ class UrlEncoder extends EncodeDecoderBase {
 			$this->encodePostVarSets();
 			$this->handleFileName();
 
-			$this->addRemainingUrlParameters();
 			$this->trimMultipleSlashes();
+			$this->addRemainingUrlParameters();
 
 			if ($this->encodedUrl === '') {
 				$emptyUrlReturnValue = $this->configuration->get('init/emptyUrlReturnValue') ?: '/';


### PR DESCRIPTION
The trimming of multiple slashes at the end of a speaking URL
is now performed before adding remaining URL parameters.

This cleans up multiple slashes at the end of URLs that have
additional GET parameters:

/my/url/with/params///?param1=value1

is now cleaned up and looks like:

/my/url/with/params/?param1=value1