### PR TITLE
[BUGFIX] 'redirect_goodUpperDir' with multiple slashes or bad parts in good URL (#437)

### DIFF
--- a/Classes/Decoder/UrlDecoder.php
+++ b/Classes/Decoder/UrlDecoder.php
@@ -1089,7 +1089,7 @@ class UrlDecoder extends EncodeDecoderBase implements SingletonInterface {
 				} while ($replaced > 0);
 			} else {
 				// There is a unrecognized postVarSetKey
-				$badPathPartPos = strpos($this->originalPath, $badPathPart);
+				$badPathPartPos = strrpos($this->originalPath, $badPathPart);
 				if ($badPathPartPos > 0) {
 					// We also want to get rid of one slash
 					$badPathPartPos--;

--- a/Classes/Decoder/UrlDecoder.php
+++ b/Classes/Decoder/UrlDecoder.php
@@ -1079,14 +1079,24 @@ class UrlDecoder extends EncodeDecoderBase implements SingletonInterface {
 		if ($failureMode == 'redirect_goodUpperDir') {
 			$nonProcessedArray = array($postVarSetKey) + $pathSegments;
 			$badPathPart = implode('/', $nonProcessedArray);
-			$badPathPartPos = strpos($this->originalPath, $badPathPart);
 			$badPathPartLength = strlen($badPathPart);
-			if ($badPathPartPos > 0) {
-				// We also want to get rid of one slash
-				$badPathPartPos--;
-				$badPathPartLength++;
+			if (strpos($badPathPart, '/') !== FALSE || $badPathPartLength === 0) {
+				// There are two or more adjacent slashes in the URL, e.g. "good/good//index.html" or "good/good//bad///index.html"
+				$goodPath = $this->originalPath;
+				// Remove multiple slashes
+				do {
+					$goodPath = str_replace('//', '/', $goodPath, $replaced);
+				} while ($replaced > 0);
+			} else {
+				// There is a unrecognized postVarSetKey
+				$badPathPartPos = strpos($this->originalPath, $badPathPart);
+				if ($badPathPartPos > 0) {
+					// We also want to get rid of one slash
+					$badPathPartPos--;
+					$badPathPartLength++;
+				}
+				$goodPath = substr($this->originalPath, 0, $badPathPartPos) . substr($this->originalPath, $badPathPartPos + $badPathPartLength);
 			}
-			$goodPath = substr($this->originalPath, 0, $badPathPartPos) . substr($this->originalPath, $badPathPartPos + $badPathPartLength);
 			@ob_end_clean();
 			header(self::REDIRECT_STATUS_HEADER);
 			header(self::REDIRECT_INFO_HEADER  . ': postVarSet_failureMode redirect for ' . $postVarSetKey);


### PR DESCRIPTION
When using `redirect_goodUpperDir` handle multiple slashes in a requested URL by replacing all ocurrences of adjacent slashes by a single slash instead of logging a PHP warning and redirecting to the same wrong URL.

`good/good//index.html` redirects to `good/good/index.html`
`good/good//bad///index.html` redirects to `good/good/bad/index.html`, which redirects to `good/good/index.html`

Also search for the bad URL part starting from the back instead of from the front of the string. This lead to wrong URLs if the bad URL part was e.g. a single character which is also part of the valid base URL:

If e.g. the valid URL is 
`http://example.org/en/imprint/index.html`
and 
`http://example.org/en/imprint/in/index.html`
is requested, without the patch the bad part `in` is not replaced where it is actually wrong but in the word `imprint`, so you got redirected to 
`http://example.org/en/impt/in/index.html`.

By starting to search from the back the correct bad part is found and you get redirected to to correct URL `http://example.org/en/imprint/index.html`

Fixes #437, #270