### PR TITLE
Changed the dependency of typo3/cms-core to be compatible with LTS ve…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "typo3-ter/realurl": "self.version"
     },
     "require": {
-        "typo3/cms-core": ">=6.2.0,<8.7.0",
+        "typo3/cms-core": ">=6.2.0,<8.8.0",
         "php": ">=5.4.0"
     },
     "require-dev": {


### PR DESCRIPTION
With this change realurl works with CMS8 LTS as well. Tested it and found no problems with just raising the version constraint.

Fixes #453