### PR TITLE
Set hostnames after automatic configuration was performed

### DIFF
--- a/Classes/Configuration/ConfigurationReader.php
+++ b/Classes/Configuration/ConfigurationReader.php
@@ -107,9 +107,9 @@ class ConfigurationReader {
 		$this->utility = GeneralUtility::makeInstance('DmitryDulepov\\Realurl\\Utility', $this);
 
 		try {
-			$this->setHostnames();
 			$this->loadExtConfiguration();
 			$this->performAutomaticConfiguration();
+			$this->setHostnames();
 			$this->setConfigurationForTheCurrentDomain();
 			$this->postProcessConfiguration();
 		}


### PR DESCRIPTION
When the `realurl_autoconf.php` file is missing then an exception is thrown:

> Core: Exception handler (WEB): Uncaught TYPO3 Exception: #1420480928: RealURL was not able to find the root page id for the domain "www.example.com" | Exception thrown in file /var/www/html/web/typo3conf/ext/realurl/Classes/Configuration/ConfigurationReader.php in line 496.

The reason is that the hostnames can only be determined after the automatic configuration was performed. That means that the first user after a deployment will see an error page. Setting the hostnames after the automatic configuration should not have any other side effects but should solve this issue.

If you need any further details let me know.
