### PR TITLE
Possibly remove leading slash from siteScript

### DIFF
--- a/Classes/Decoder/UrlDecoder.php
+++ b/Classes/Decoder/UrlDecoder.php
@@ -1180,10 +1180,11 @@ class UrlDecoder extends EncodeDecoderBase implements SingletonInterface {
 	 * @return bool
 	 */
 	protected function isSpeakingUrl() {
+		$tss = ltrim($this->siteScript, "/"); // possibly remove leading slash
 		return $this->siteScript &&
-			substr($this->siteScript, 0, 9) !== 'index.php' &&
-			substr($this->siteScript, 0, 1) !== '?' &&
-			$this->siteScript !== 'favicon.ico' &&
+			substr($tss, 0, 9) !== 'index.php' &&
+			substr($tss, 0, 1) !== '?' &&
+			$tss !== 'favicon.ico' &&
 			(!$this->configuration->get('init/respectSimulateStaticURLs') || !preg_match('/^[a-z0-9\-]+\.([a-z0-9_\-]+)(\.\d+)?\.html/i', $this->siteScript))
 		;
 	}


### PR DESCRIPTION
There might be a leading slash in $this->siteScript, so isSpeakingUrl() would return true for e.g. /index.php?id=54&L=0 and then show the page not found-error 'Reason: Segment "index.php" was not a keyword for a postVarSet'.