### PR TITLE
Sys language uid hook

### DIFF
--- a/Classes/Decoder/UrlDecoder.php
+++ b/Classes/Decoder/UrlDecoder.php
@@ -329,16 +329,22 @@ class UrlDecoder extends EncodeDecoderBase implements SingletonInterface {
                     $GLOBALS['TT'] = new \TYPO3\CMS\Core\TimeTracker\TimeTracker();
                     $GLOBALS['TT']->start();
                 }*/
-
-                $GLOBALS['TSFE'] = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance( $name,  $GLOBALS['TYPO3_CONF_VARS'], $page['uid'], $type );
-		$GLOBALS['TSFE']->showHiddenPage = true;
-                $GLOBALS['TSFE']->connectToDB();
-                $GLOBALS['TSFE']->initFEuser();
-                //\TYPO3\CMS\Core\Utility\GeneralUtility::devLog("Retrieving sys_language_uid: ", "realurl", 1, array(0.5));
-                $GLOBALS['TSFE']->determineId();
-                //\TYPO3\CMS\Core\Utility\GeneralUtility::devLog("Retrieving sys_language_uid: ", "realurl", 1, array(1));
-                $GLOBALS['TSFE']->initTemplate();
-                $GLOBALS['TSFE']->getConfigArray();
+		try
+                {
+                	$GLOBALS['TSFE'] = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance( $name,  $GLOBALS['TYPO3_CONF_VARS'], $page['uid'], $type );
+			$GLOBALS['TSFE']->showHiddenPage = true;
+                	$GLOBALS['TSFE']->connectToDB();
+                	$GLOBALS['TSFE']->initFEuser();
+                	//\TYPO3\CMS\Core\Utility\GeneralUtility::devLog("Retrieving sys_language_uid: ", "realurl", 1, array(0.5));
+                	$GLOBALS['TSFE']->determineId();
+                	//\TYPO3\CMS\Core\Utility\GeneralUtility::devLog("Retrieving sys_language_uid: ", "realurl", 1, array(1));
+                	$GLOBALS['TSFE']->initTemplate();
+                	$GLOBALS['TSFE']->getConfigArray();
+		}
+		catch(\TYPO3\TypoScript\Exception\RuntimeException $exception) {
+			\TYPO3\CMS\Core\Utility\GeneralUtility::devLog("error during sys_language_uid chack", "realurl", 1, array($exception));
+			return 0;
+		}
 
                 //\TYPO3\CMS\Core\Utility\GeneralUtility::devLog("LOBALS['TSFE']->getConfigArray(): ", "realurl", 1, $GLOBALS['TSFE']->config);
                 return $GLOBALS['TSFE']->config['config']['sys_language_uid'];
@@ -387,7 +393,7 @@ class UrlDecoder extends EncodeDecoderBase implements SingletonInterface {
                                 $languageID = $perPageSysLangID;
                         }
 
-			\TYPO3\CMS\Core\Utility\GeneralUtility::devLog("checking fields for page: ", "realurl", 1, array($page['title'], $languageID));
+			//\TYPO3\CMS\Core\Utility\GeneralUtility::devLog("checking fields for page: ", "realurl", 1, array($page['title'], $languageID));
 
 
 			if ($languageID > 0 && !isset($page['_PAGES_OVERLAY']) && (empty($languageExceptionUids) || !GeneralUtility::inList($languageExceptionUids, $languageID))) {

--- a/Classes/Decoder/UrlDecoder.php
+++ b/Classes/Decoder/UrlDecoder.php
@@ -186,11 +186,6 @@ class UrlDecoder extends EncodeDecoderBase implements SingletonInterface {
         protected function callPreLanguageOverlayHooks(array $params) {
                 if (is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl']['decodeSpURL_preLanguageOverlay'])) {
 			foreach($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl']['decodeSpURL_preLanguageOverlay'] as $classRef) {
-                                $hookParams = array(
-                                        'pObj' => &$this,
-                                        'params' => $params,
-                                        'URL' => &$this->speakingUri,
-                                );
 				\TYPO3\CMS\Core\Utility\GeneralUtility::getUserObj($classRef)->preLanguageOverlayDecoderHook($this, $params, $this->speakingUri);
                         }
                 }

--- a/Classes/Decoder/UrlDecoder.php
+++ b/Classes/Decoder/UrlDecoder.php
@@ -333,8 +333,16 @@ class UrlDecoder extends EncodeDecoderBase implements SingletonInterface {
                 {
                 	$GLOBALS['TSFE'] = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance( $name,  $GLOBALS['TYPO3_CONF_VARS'], $page['uid'], $type );
 			$GLOBALS['TSFE']->showHiddenPage = true;
+			$GLOBALS['TSFE']->login_user = true;
                 	$GLOBALS['TSFE']->connectToDB();
                 	$GLOBALS['TSFE']->initFEuser();
+
+			$GLOBALS['TSFE']->fe_user->checkPid = '';
+			$info = $GLOBALS['TSFE']->fe_user->getAuthInfoArray();
+			$user = $GLOBALS['TSFE']->fe_user->fetchUserRecord($info['db_user'], 'mitarbeiter');
+			$GLOBALS['TSFE']->fe_user->createUserSession($user);
+			$GLOBALS['TSFE']->fe_user->user = $GLOBALS['TSFE']->fe_user->fetchUserSession();
+
                 	//\TYPO3\CMS\Core\Utility\GeneralUtility::devLog("Retrieving sys_language_uid: ", "realurl", 1, array(0.5));
                 	$GLOBALS['TSFE']->determineId();
                 	//\TYPO3\CMS\Core\Utility\GeneralUtility::devLog("Retrieving sys_language_uid: ", "realurl", 1, array(1));

--- a/Classes/Decoder/UrlDecoder.php
+++ b/Classes/Decoder/UrlDecoder.php
@@ -357,7 +357,8 @@ class UrlDecoder extends EncodeDecoderBase implements SingletonInterface {
 			}
 			$languageExceptionUids = (string)$this->configuration->get('pagePath/languageExceptionUids');
 
-                        $languageID = $this->detectedLanguageId;
+			$languageID = $this->detectedLanguageId;
+			// pass languageID as a reference, so the hooks can modify it
 			$this->callPreLanguageOverlayHooks(array('languageID' => &$languageID, 'page' => $page));
 
 			if ($languageID > 0 && !isset($page['_PAGES_OVERLAY']) && (empty($languageExceptionUids) || !GeneralUtility::inList($languageExceptionUids, $languageID))) {


### PR DESCRIPTION
Added a Hook that runs before the decision whether a page language overlay is fetched before evaluating page identifiers and url segments.

This can, for example, be used to evaluate the sys_language_uid setting to determine a page's currently targeted language. The sys_language_uid setting is often used to change the default language within the page tree.