### PR TITLE
[Bugfix] Proper crossdomain linking detection

### DIFF
--- a/Classes/Decoder/UrlDecoder.php
+++ b/Classes/Decoder/UrlDecoder.php
@@ -1157,6 +1157,10 @@ class UrlDecoder extends EncodeDecoderBase implements SingletonInterface {
 				$result = true;
 				break;
 			}
+			if ($page['php_tree_stop'] || $page['is_siteroot']) {
+				// Pages beyond this one cannot be root pages (we do not support nested domains!)
+				break;
+			}
 		}
 
 		return $result;

--- a/Classes/Encoder/UrlEncoder.php
+++ b/Classes/Encoder/UrlEncoder.php
@@ -1128,7 +1128,7 @@ class UrlEncoder extends EncodeDecoderBase {
 	protected function isLinkingAcrossDomains() {
 		$result = true;
 
-		foreach (array_reverse($this->tsfe->rootLine) as $page) {
+		foreach ($this->tsfe->rootLine as $page) {
 			if ($page['uid'] == $this->rootPageId) {
 				$result = false;
 				break;


### PR DESCRIPTION
After testing, it seems isLinkingAcrossDomains (introduced in https://github.com/dmitryd/typo3-realurl/commit/1dbbe84da5d5bd419f2418c2f73fcb6c853b395c) always returns true... This is a suggested fix, as well as a small change on the similar function isPageInRootlineOfRootPage in UrlDecoder so that both functions are consistent with each other.