### PR TITLE
A primary key for the table tx_realurl_uniqalias_cache_map

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -26,6 +26,7 @@ CREATE TABLE tx_realurl_uniqalias_cache_map (
 	alias_uid int(11) DEFAULT '0' NOT NULL,
 	url_cache_id int(11) DEFAULT '0' NOT NULL,
 
+	PRIMARY KEY (alias_uid,url_cache_id),
 	KEY check_existence (alias_uid,url_cache_id)
 ) ENGINE=InnoDB;
 


### PR DESCRIPTION
When using Percona XtraDB Cluster in strict mode = ENFORCING or MASTER (highly recommanded) it's not permit to have a table without a primary key. Then I'm proposing to add a primary key for the table tx_realurl_uniqalias_cache_map.