### PR TITLE
[BUGFIX] Fix ignored `utm_*` get-parameters list

### DIFF
--- a/Classes/Configuration/ConfigurationReader.php
+++ b/Classes/Configuration/ConfigurationReader.php
@@ -85,7 +85,7 @@ class ConfigurationReader {
 	 */
 	protected $defaultValues = array(
 		'cache/banUrlsRegExp' => '/tx_powermail_pi1%5Baction%5D=create|tx_solr|tx_indexedsearch|tx_kesearch|(?:^|\?|&)q=/',
-		'cache/ignoredGetParametersRegExp' => '/^(?:gclid|utm_[a-z]+|pk_campaign|pk_kwd|TSFE_ADMIN_PANEL.*)$/',
+		'cache/ignoredGetParametersRegExp' => '/^(?:gclid|utm_(source|medium|campaign|term|content)|pk_campaign|pk_kwd|TSFE_ADMIN_PANEL.*)$/',
 		'fileName/acceptHTMLsuffix' => TRUE,
 		'fileName/defaultToHTMLsuffixOnPrev' => FALSE,
 		'init/appendMissingSlash' => 'ifNotFile,redirect[301]',


### PR DESCRIPTION
By default, TYPO3 stores the following values in the configuration `cHashExcludedParameters`: `utm_source, utm_medium, utm_campaign, utm_term, utm_content`.

Currently, RealURL accepts any `utm_[a-z]` parameter.

This commit sets this list in the RealURL ignored get-parameters list, to prevent any `utm_*` parameter that is not supported from being added.