### PR TITLE
Fix redirect_goodUpperDir bugs

### DIFF
--- a/Classes/Decoder/UrlDecoder.php
+++ b/Classes/Decoder/UrlDecoder.php
@@ -1094,10 +1094,10 @@ class UrlDecoder extends EncodeDecoderBase implements SingletonInterface {
 	protected function handleNonExistingPostVarSet($pageId, $postVarSetKey, array &$pathSegments) {
 		$failureMode = $this->configuration->get('init/postVarSet_failureMode');
 		if ($failureMode == 'redirect_goodUpperDir') {
-			$nonProcessedArray = array($postVarSetKey) + $pathSegments;
+			$nonProcessedArray = array_merge(array($postVarSetKey), $pathSegments);
 			$badPathPart = implode('/', $nonProcessedArray);
 			$badPathPartLength = strlen($badPathPart);
-			if (strpos($badPathPart, '/') !== FALSE || $badPathPartLength === 0) {
+			if (strpos($badPathPart, '//') !== FALSE || $badPathPartLength === 0) {
 				// There are two or more adjacent slashes in the URL, e.g. "good/good//index.html" or "good/good//bad///index.html"
 				$goodPath = $this->originalPath;
 				// Remove multiple slashes


### PR DESCRIPTION
http://example.org/bad1/bad2/bad3/ and http://example.org/good/bad1/bad2/bad3/ creates to a wrong redirect.

If `$pathSegments` contains more than one element the operation `$nonProcessedArray = array($postVarSetKey) + $pathSegments` leads to only the last element being appended to the `$badPathPart`, e.g. http://example.org/bad1/bad2/bad3/ leads to `$badPathPart = 'bad1/bad3';` which will not be found in `$this->originalPath`. `$nonProcessedArray = array_merge(array($postVarSetKey), $pathSegments)` correctly identifies `$badPathPart ='bad1/bad2/bad3';` creating the correct redirect.

Currently the badPathPart handling for two or more adjacent slashes is triggered even if there is only one slash, using `strpos($badPathPart, '//')` yields the correct behaviour.