### PR TITLE
added support for 'optional' keyword

### DIFF
--- a/Classes/Decoder/UrlDecoder.php
+++ b/Classes/Decoder/UrlDecoder.php
@@ -740,6 +740,10 @@ class UrlDecoder extends EncodeDecoderBase implements SingletonInterface {
 	 */
 	protected function decodeUrlParameterBlockUseAsIs(array $configuration, $getVarValue, array &$requestVariables) {
 		// TODO Possible conditions: if int, if notEmpty, etc
+    // skip optional params
+    if(isset($configuration['optional']) && $configuration['optional']) {
+      return false;
+    }
 		$requestVariables[$configuration['GETvar']] = $getVarValue;
 
 		return TRUE;
@@ -759,7 +763,7 @@ class UrlDecoder extends EncodeDecoderBase implements SingletonInterface {
 		if (isset($configuration['lookUpTable'])) {
 			$value = $this->convertAliasToId($configuration['lookUpTable'], $getVarValue);
 			if (!MathUtility::canBeInterpretedAsInteger($value) && $value === $getVarValue) {
-				if ($configuration['lookUpTable']['enable404forInvalidAlias']) {
+				if ($configuration['lookUpTable']['enable404forInvalidAlias'] && (!isset($configuration['optional']) || !$configuration['optional']) ) {
 					$this->throw404('Could not map alias "' . $value . '" to an id.');
 				}
 			} else {

--- a/Classes/Encoder/UrlEncoder.php
+++ b/Classes/Encoder/UrlEncoder.php
@@ -767,6 +767,9 @@ class UrlEncoder extends EncodeDecoderBase {
 
 		if (isset($configuration['GETvar'])) {
 			$getVarName = $configuration['GETvar'];
+			if(!isset($this->urlParameters[$getVarName]) && isset($configuration['optional']) && $configuration['optional']) {
+			  return;
+      }
 			$getVarValue = isset($this->urlParameters[$getVarName]) ? $this->urlParameters[$getVarName] : '';
 
 			if (!isset($configuration['cond']) || $this->checkLegacyCondition($configuration['cond'], $previousValue)) {


### PR DESCRIPTION
Encoding 
Parameter configuration will be skipped if the parameter is not set 

Decoding: 
decodeUrlParameterBlockUseAsIs does not handle optional parameters (so the Parameter can be handled by next configuration)
decodeUrlParameterBlockUsingLookupTable will never throw 404 errors for invalid aliases if optional
