### PR TITLE
[BUGFIX] #504: Prevent exception if $GLOBALS['TYPO3_CONF_VARS']['FE']…

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -71,6 +71,9 @@ if (!is_array($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['scheduler']['tasks']['T
 }
 
 // Exclude gclid from cHash because TYPO3 does not do that
+if (!is_array($GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['excludedParameters'])) {
+    $GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['excludedParameters'] = array();
+}
 if (!in_array('gclid', $GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['excludedParameters'])) {
     $GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['excludedParameters'][] = 'gclid';
     $GLOBALS['TYPO3_CONF_VARS']['FE']['cHashExcludedParameters'] .= ', gclid';


### PR DESCRIPTION
…['cacheHash']['excludedParameters'] is not initialized