### PR TITLE
[BUGFIX] Ensure higher priority of $_GET-vars

### DIFF
--- a/Classes/Decoder/UrlDecoder.php
+++ b/Classes/Decoder/UrlDecoder.php
@@ -1274,10 +1274,10 @@ class UrlDecoder extends EncodeDecoderBase implements SingletonInterface {
 			if (!is_array($getVars)) {
 				$getVars = array();
 			}
-			ArrayUtility::mergeRecursiveWithOverrule($getVars, $getVarsToSet, true, true, false);
+			ArrayUtility::mergeRecursiveWithOverrule($getVarsToSet, $getVars, true, true, false);
 
 			// Store the "new" $_GET-params back
-			GeneralUtility::_GETset($getVars);
+			GeneralUtility::_GETset($getVarsToSet);
 		}
 	}
 


### PR DESCRIPTION
Correct the merge order of variables from $_GET and GETvars from domains configuration. $_GET must have the higher priority compared to GETvars.

The wrong order was introduced in b0945b0. I think it was not by intention, but a mistake, because there is already comment _"Overwrite with $\_GET-params that $\_GET-parmas have a "higher" priority"_.

Two examples where the wrong order causes problems:

1.) Language switcher in View-Module (introduced with 7.x):
It uses non-RealURL-encoded links using the current domain and adds the L-parameter with the selected sys_language_uid to preview the page in the respective language (see [code](https://github.com/TYPO3/TYPO3.CMS/blob/a4cd49c3307d2953ef54134406d9ce0c823730b2/typo3/sysext/viewpage/Classes/Controller/ViewModuleController.php#L326)). This does not work, since the domains configuration overwrites the added L-parameter.

2.) EXT:solr page indexing:
The page indexer also builds a non-RealURL-encoded URL using the current domain and adds the L-parameter to fetch translated pages (see [code](https://github.com/TYPO3-Solr/ext-solr/blob/329461f14cbbb8df236ef1aca540dad2507cc936/Classes/IndexQueue/PageIndexer.php#L273)). Because the L-parameter gets overwritten by domains configuration, the indexed results are wrong.

P.S.: Even if this doesn't really matter, but just to mention, the corrected merge order also correlates to the behaviour of RealURL v1.x.