### PR TITLE
[BUGFIX] Drop deprecated GeneralUtility::requireOnce call

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -26,7 +26,7 @@ if (!function_exists('includeRealurlConfiguration')) {
 
 		$realurlConfigurationFile = trim($configuration['configFile']);
 		if ($realurlConfigurationFile && @file_exists(PATH_site . $realurlConfigurationFile)) {
-			\TYPO3\CMS\Core\Utility\GeneralUtility::requireOnce(PATH_site . $realurlConfigurationFile);
+			require_once(PATH_site . $realurlConfigurationFile);
 		}
 		elseif ($configuration['enableAutoConf']) {
 			/** @noinspection PhpIncludeInspection */


### PR DESCRIPTION
Drop the call of GeneralUtility::requireOnce and replace it with the PHP native require_once