### PR TITLE
Remove pointless explicit transaction

### DIFF
--- a/Classes/Cache/DatabaseCache.php
+++ b/Classes/Cache/DatabaseCache.php
@@ -424,7 +424,6 @@ class DatabaseCache implements CacheInterface, SingletonInterface {
 	protected function limitTableRecords($tableName) {
 		$cleanedUp = false;
 		if ((mt_rand(0, mt_getrandmax()) % 5000) == 0) {
-			$this->databaseConnection->sql_query('START TRANSACTION');
 			// Using exec_SELECTgetRows instead of exec_SELECTsingleRow because we need to set the limit
 			list($row) = $this->databaseConnection->exec_SELECTgetRows('uid', $tableName,
 				'', '', 'uid DESC', self::$maximumNumberOfRecords . ',1'
@@ -432,7 +431,6 @@ class DatabaseCache implements CacheInterface, SingletonInterface {
 			if (is_array($row)) {
 				$this->databaseConnection->exec_DELETEquery($tableName, 'uid<=' . $row['uid']);
 			}
-			$this->databaseConnection->sql_query('COMMIT');
 			$cleanedUp = ($this->databaseConnection->sql_affected_rows() > 0);
 		}
 


### PR DESCRIPTION
In the limitTableRecords function a periodic cleanup is triggered, that
comes down to a select and delete function, which is run inside an
explicit transaction. Given that we only have a single data modifying
operation that doesn't seem to serve any purpose.

The reason for our interest in this change, is that we're seeing some heavy periodic locking activity hitting the tx_realurl_urldata table, and the cause seems to be this transaction.
It's important to remember that, when using MySQL and starting a transaction, you're by default setting the database to use the "Repeatable Read" isolation mode. Using "repeatable read" means that any select you perform will set locks for the rows you access, until the transaction is completed.

I'll note that in other parts of the code you're using transactions in places where it makes sense, but in those cases you should seriously consider lowering the isolation level to READ-COMMITTED, to prevent excessive locking. I don't see any parts of RealURL that would need "Repeatable Read".