### PR TITLE
cache not updated if a page is renamed through a workspace

### DIFF
--- a/Classes/Decoder/UrlDecoder.php
+++ b/Classes/Decoder/UrlDecoder.php
@@ -1122,8 +1122,9 @@ class UrlDecoder extends EncodeDecoderBase implements SingletonInterface {
 	protected function handleNonExistingPostVarSet($pageId, $postVarSetKey, array &$pathSegments) {
 		$failureMode = $this->configuration->get('init/postVarSet_failureMode');
 		if ($failureMode == 'redirect_goodUpperDir') {
-			$nonProcessedArray = array($postVarSetKey) + $pathSegments;
+			$nonProcessedArray = array_merge( array($postVarSetKey), $pathSegments );
 			$badPathPart = implode('/', $nonProcessedArray);
+			$badPathPartPos = strrpos($this->originalPath, $badPathPart);
 			$badPathPartLength = strlen($badPathPart);
 			if (strpos($badPathPart, '/') !== FALSE || $badPathPartLength === 0) {
 				// There are two or more adjacent slashes in the URL, e.g. "good/good//index.html" or "good/good//bad///index.html"

--- a/Classes/Hooks/DataHandler.php
+++ b/Classes/Hooks/DataHandler.php
@@ -79,7 +79,7 @@ class DataHandler implements SingletonInterface {
 	 * @param int $id
 	 */
 	public function processCmdmap_postProcess($command, $table, $id) {
-		if ($command === 'move' && $table === 'pages') {
+		if ( ( $command === 'move' || $command === "version" ) && $table === 'pages') {
 			$this->expireCachesForPageAndSubpages((int)$id, 0);
 
 			$languageOverlays = $this->getRecordsByField('pages_language_overlay', 'pid', $id);


### PR DESCRIPTION
I know workspaces are less used, but where I work we really need them... So this code solve a cache bug when a page is being renamed in a workspace then published to live. The Url cache is now updated if a version change occurs.