### PR TITLE
Update UrlDecoder.php

### DIFF
--- a/Classes/Decoder/UrlDecoder.php
+++ b/Classes/Decoder/UrlDecoder.php
@@ -1378,6 +1378,9 @@ class UrlDecoder extends EncodeDecoderBase implements SingletonInterface {
 				$this->pageRepository->enableFields('pages', 1, array('fe_group' => true)),
 				'', 'sorting'
 		);
+		if (!is_array($rows)){
+			return $result;
+		}
 		foreach ($rows as $row) {
 			if ($this->isPageInRootlineOfRootPage((int)$row['uid'])) {
 				// Found it!


### PR DESCRIPTION
When DB::exec_SELECTgetRows() returns non traversable method throws an InvalidOffset Exception and the realurl cache for requested page is invalidated in such a way that the page cannot be accessed until a flush::all command is issued.