### PR TITLE
Language uid hook

### DIFF
--- a/Classes/Decoder/UrlDecoder.php
+++ b/Classes/Decoder/UrlDecoder.php
@@ -178,6 +178,20 @@ class UrlDecoder extends EncodeDecoderBase implements SingletonInterface {
 		}
 	}
 
+        /**
+         * Calls user-defined hooks.
+         *
+         * @param array $params
+         */
+        protected function callPreLanguageOverlayHooks(array $params) {
+                if (is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl']['decodeSpURL_preLanguageOverlay'])) {
+			foreach($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl']['decodeSpURL_preLanguageOverlay'] as $classRef) {
+				\TYPO3\CMS\Core\Utility\GeneralUtility::getUserObj($classRef)->preLanguageOverlayDecoderHook($this, $params, $this->speakingUri);
+                        }
+                }
+        }
+
+
 	/**
 	 * Checks if the decoder can execute.
 	 *
@@ -356,8 +370,13 @@ class UrlDecoder extends EncodeDecoderBase implements SingletonInterface {
 				}
 			}
 			$languageExceptionUids = (string)$this->configuration->get('pagePath/languageExceptionUids');
-			if ($this->detectedLanguageId > 0 && !isset($page['_PAGES_OVERLAY']) && (empty($languageExceptionUids) || !GeneralUtility::inList($languageExceptionUids, $this->detectedLanguageId))) {
-				$page = $this->pageRepository->getPageOverlay($page, (int)$this->detectedLanguageId);
+
+			$languageID = $this->detectedLanguageId;
+			// pass languageID as a reference, so the hooks can modify it
+			$this->callPreLanguageOverlayHooks(array('languageID' => &$languageID, 'page' => $page));
+
+			if ($languageID > 0 && !isset($page['_PAGES_OVERLAY']) && (empty($languageExceptionUids) || !GeneralUtility::inList($languageExceptionUids, $languageID))) {
+				$page = $this->pageRepository->getPageOverlay($page, (int)$languageID);
 			}
 			foreach (self::$pageTitleFields as $field) {
 				if (isset($page[$field]) && $page[$field] !== '' && $this->utility->convertToSafeString($page[$field], $this->separatorCharacter) === $segment) {


### PR DESCRIPTION
Added a Hook that runs before the decision whether a page language overlay is fetched before evaluating page identifiers and url segments.

This can, for example, be used to evaluate the sys_language_uid setting to determine a page's currently targeted language. The sys_language_uid setting is often used to change the default language within the page tree.