### PR TITLE
[Feature] Append (Copy) to language overlay titles

### DIFF
--- a/Classes/Hooks/DataHandler.php
+++ b/Classes/Hooks/DataHandler.php
@@ -350,7 +350,7 @@ class DataHandler implements SingletonInterface {
 	private function getPageOverlayCopyHeader($table, $pid, $value, $count, $sysLanguageUid, $prevTitle = '') {
 		// Set title value to check for:
 		if ($count) {
-		    $checkTitle = $value . rtrim(' ' . sprintf($this->dataHandler->prependLabel($table), $count));
+		    $checkTitle = $value . rtrim(' ' . sprintf($this->dataHandler->prependLabel('pages'), $count));
 		} else {
 		    $checkTitle = $value;
 		}


### PR DESCRIPTION
This PR appends "(copy x)" not only to the title of the copied pages, but also to the title of the copied language overlays. This solves an issue we often have, and documented here : https://forge.typo3.org/issues/76038
When copying a given page with several language overlays, the copied page can have "(copy 1)" appended, but not language overlays, resulting in many URL conflicts - not always properly identified by editors since language overlays don't appear in the menu tree.

As this core "bug" is mostly an issue when using realurl, I assumed it would make sense to apply the fix within realurl itself. Besides I expect it will have a rather low priority for the core team.

It relies on two hooks : `processCmdmap_preProcess` before the copy is performed (to determine the need for a title change), and `processCmdmap_afterFinish` to apply the title change (once we know the Id of the newly created page). It is adapted from the core code managing the "(copy)" tags within DataHandler.