### PR TITLE
Remove logging of debug information when bad "L" param was discovered

### DIFF
--- a/Classes/Encoder/UrlEncoder.php
+++ b/Classes/Encoder/UrlEncoder.php
@@ -1586,7 +1586,7 @@ class UrlEncoder extends EncodeDecoderBase {
 				addslashes($sysLanguageUid)
 			);
 			$this->tsfe->set_no_cache($message);
-			$this->logger->error($message, debug_backtrace());
+			$this->logger->error($message);
 			throw new InvalidLanguageParameterException($sysLanguageUid);
 		}
 	}


### PR DESCRIPTION
As some search engine bots visit our site with an invalid "L" param every few hours, our typo3temp logfile grew up to several GB. This is caused by logging the debug_backtrace() call, which should be removed.