### PR TITLE
[FIX] reset encodedUrl for use with ext:crawler

### DIFF
--- a/Classes/Encoder/UrlEncoder.php
+++ b/Classes/Encoder/UrlEncoder.php
@@ -126,6 +126,7 @@ class UrlEncoder extends EncodeDecoderBase {
 	 * @return void
 	 */
 	public function encodeUrl(array &$encoderParameters) {
+	    	$this->encodedUrl = '';
 		$this->callEarlyHook($encoderParameters);
 		$this->encoderParameters = $encoderParameters;
 		$this->urlToEncode = $encoderParameters['LD']['totalURL'];


### PR DESCRIPTION
Hi @dmitryd. I have a fix in combination with this pull request
https://github.com/AOEpeople/crawler/pull/215. It is a simple fix for crawler usage with activated realurl option. Maybe you have another solution to reset the property encodedUrl.