### PR TITLE
[BUGFIX] fix missing cHash configuration issue

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -71,7 +71,9 @@ if (!is_array($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['scheduler']['tasks']['T
 }
 
 // Exclude gclid from cHash because TYPO3 does not do that
-if (!in_array('gclid', $GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['excludedParameters'])) {
+if (!is_array($GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['excludedParameters'])
+    || !in_array('gclid', $GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['excludedParameters'])
+) {
     $GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['excludedParameters'][] = 'gclid';
     $GLOBALS['TYPO3_CONF_VARS']['FE']['cHashExcludedParameters'] .= ', gclid';
 }


### PR DESCRIPTION
If the TYPO3 bootstrap mechanism wasn't executet completely yet,
the check for gclid in cacheHash->excludedParameters ends
up in an php error, because the array isn't generated yet.
This happens for example with helhum/typo3_console help
command.

To solve this, add a condition to check if the array even exists.