### PR TITLE
Remove warning about missing absRefPrefix configuration

### DIFF
--- a/Classes/Encoder/UrlEncoder.php
+++ b/Classes/Encoder/UrlEncoder.php
@@ -1336,9 +1336,6 @@ class UrlEncoder extends EncodeDecoderBase {
 				$this->encodedUrl = $this->tsfe->absRefPrefix . $this->encodedUrl;
 			}
 		}
-		if (empty($this->tsfe->absRefPrefix)) {
-			$this->logger->warning('config.absRefPrefix is not set! Please, check your TypoScript configuration!');
-		}
 	}
 
 	/**


### PR DESCRIPTION
The warning will be logged whenever an URL is created because of a bug within TYPO3.

See:
- #548 (https://github.com/dmitryd/typo3-realurl/issues/548)
- https://forge.typo3.org/issues/82939