### PR TITLE
[BUGFIX] #504: Prevent warning when $GLOBALS['TYPO3_CONF_VARS']['FE']…

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -71,7 +71,7 @@ if (!is_array($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['scheduler']['tasks']['T
 }
 
 // Exclude gclid from cHash because TYPO3 does not do that
-if (!in_array('gclid', $GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['excludedParameters'])) {
+if (isset($GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['excludedParameters']) && !in_array('gclid', $GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['excludedParameters'])) {
     $GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['excludedParameters'][] = 'gclid';
     $GLOBALS['TYPO3_CONF_VARS']['FE']['cHashExcludedParameters'] .= ', gclid';
 }


### PR DESCRIPTION
…['cacheHash']['excludedParameters'] is not set