### PR TITLE
[FEATURE] Alias per page

### DIFF
--- a/Classes/Controller/AliasesController.php
+++ b/Classes/Controller/AliasesController.php
@@ -160,6 +160,7 @@ class AliasesController extends BackendModuleController {
 				$query->equals('valueAlias', $aliasValue),
 				$query->equals('tablename', $alias->getTablename()),
 				$query->equals('lang', $alias->getLang()),
+				$query->equals('pageId', $alias->getPageId()),
 				$query->logicalNot($query->equals('uid', (int)$alias->getUid()))
 			)));
 
@@ -258,6 +259,7 @@ class AliasesController extends BackendModuleController {
 		$query->matching(count($conditons) > 1 ? $query->logicalAnd($conditons) : reset($conditons));
 		$query->setOrderings(array(
 			'valueId' => QueryInterface::ORDER_ASCENDING,
+			'pageId' => QueryInterface::ORDER_ASCENDING,
 			'lang' => QueryInterface::ORDER_ASCENDING,
 		));
 

--- a/Classes/Decoder/UrlDecoder.php
+++ b/Classes/Decoder/UrlDecoder.php
@@ -282,14 +282,15 @@ class UrlDecoder extends EncodeDecoderBase implements SingletonInterface {
 	 *
 	 * @param array $configuration
 	 * @param string $value
+	 * @param int $pageId
 	 * @return int|string
 	 */
-	protected function convertAliasToId(array $configuration, $value) {
+	protected function convertAliasToId(array $configuration, $value, $pageId) {
 		$result = (string)$value;
 
 		// First, test if there is an entry in cache for the alias
 		if ($configuration['useUniqueCache']) {
-			$cachedId = $this->getFromAliasCacheByAliasValue($configuration, $value);
+			$cachedId = $this->getFromAliasCacheByAliasValue($configuration, $value, $pageId);
 			if (MathUtility::canBeInterpretedAsInteger($cachedId)) {
 				$result = (int)$cachedId;
 			}
@@ -757,7 +758,7 @@ class UrlDecoder extends EncodeDecoderBase implements SingletonInterface {
 		$result = FALSE;
 
 		if (isset($configuration['lookUpTable'])) {
-			$value = $this->convertAliasToId($configuration['lookUpTable'], $getVarValue);
+			$value = $this->convertAliasToId($configuration['lookUpTable'], $getVarValue, $requestVariables['id']);
 			if (!MathUtility::canBeInterpretedAsInteger($value) && $value === $getVarValue) {
 				if ($configuration['lookUpTable']['enable404forInvalidAlias']) {
 					$this->throw404('Could not map alias "' . $value . '" to an id.');

--- a/Classes/Domain/Model/Alias.php
+++ b/Classes/Domain/Model/Alias.php
@@ -48,6 +48,9 @@ class Alias extends AbstractEntity {
 	/** @var int */
 	protected $valueId;
 
+	/** @var int */
+	protected $pageId;
+
 	/**
 	 * @return int
 	 */
@@ -144,6 +147,20 @@ class Alias extends AbstractEntity {
 	 */
 	public function setValueId($valueId) {
 		$this->valueId = $valueId;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getPageId() {
+		return $this->pageId;
+	}
+
+	/**
+	 * @param int $pageId
+	 */
+	public function setPageId($pageId) {
+		$this->pageId = $pageId;
 	}
 
 	/**

--- a/Classes/EncodeDecoderBase.php
+++ b/Classes/EncodeDecoderBase.php
@@ -173,14 +173,16 @@ abstract class EncodeDecoderBase {
 	 *
 	 * @param array $configuration
 	 * @param string $aliasValue
+	 * @param int $pageId
 	 * @return int ID integer. If none is found: false
 	 */
-	protected function getFromAliasCacheByAliasValue(array $configuration, $aliasValue) {
+	protected function getFromAliasCacheByAliasValue(array $configuration, $aliasValue, $pageId) {
 		$row = $this->databaseConnection->exec_SELECTgetSingleRow('value_id', 'tx_realurl_uniqalias',
 				'value_alias=' . $this->databaseConnection->fullQuoteStr($aliasValue, 'tx_realurl_uniqalias') .
 				' AND field_alias=' . $this->databaseConnection->fullQuoteStr($configuration['alias_field'], 'tx_realurl_uniqalias') .
 				' AND field_id=' . $this->databaseConnection->fullQuoteStr($configuration['id_field'], 'tx_realurl_uniqalias') .
 				' AND tablename=' . $this->databaseConnection->fullQuoteStr($configuration['table'], 'tx_realurl_uniqalias') .
+				' AND page_id=' . intval($pageId) .
 				' AND (expire=0 OR expire>' . time() . ')');
 
 		return (is_array($row) ? (int)$row['value_id'] : false);

--- a/Classes/EncodeDecoderBase.php
+++ b/Classes/EncodeDecoderBase.php
@@ -182,7 +182,7 @@ abstract class EncodeDecoderBase {
 				' AND field_alias=' . $this->databaseConnection->fullQuoteStr($configuration['alias_field'], 'tx_realurl_uniqalias') .
 				' AND field_id=' . $this->databaseConnection->fullQuoteStr($configuration['id_field'], 'tx_realurl_uniqalias') .
 				' AND tablename=' . $this->databaseConnection->fullQuoteStr($configuration['table'], 'tx_realurl_uniqalias') .
-				' AND page_id=' . intval($pageId) .
+				(intval($pageId) > 0 ? ' AND page_id=' . intval($pageId) : '') .
 				' AND (expire=0 OR expire>' . time() . ')');
 
 		return (is_array($row) ? (int)$row['value_id'] : false);

--- a/Classes/Encoder/UrlEncoder.php
+++ b/Classes/Encoder/UrlEncoder.php
@@ -477,7 +477,7 @@ class UrlEncoder extends EncodeDecoderBase {
 		$testNewAliasValue = $newAliasValue;
 		while ($counter < $maxTry) {
 			// If the test-alias did NOT exist, it must be unique and we break out
-			$foundId = $this->getFromAliasCacheByAliasValue($configuration, $testNewAliasValue);
+			$foundId = $this->getFromAliasCacheByAliasValue($configuration, $testNewAliasValue, $this->urlParameters['id']);
 			if (!$foundId || $foundId == $idValue) {
 				$uniqueAlias = $testNewAliasValue;
 				break;
@@ -1080,6 +1080,7 @@ class UrlEncoder extends EncodeDecoderBase {
 				' AND field_id=' . $this->databaseConnection->fullQuoteStr($configuration['id_field'], 'tx_realurl_uniqalias') .
 				' AND tablename=' . $this->databaseConnection->fullQuoteStr($configuration['table'], 'tx_realurl_uniqalias') .
 				' AND lang=' . intval($languageUid) .
+				' AND page_id=' . intval($this->urlParameters['id']) .
 				($onlyThisAlias ? ' AND value_alias=' . $this->databaseConnection->fullQuoteStr($onlyThisAlias, 'tx_realurl_uniqalias') : ' AND expire=0'),
 			'', 'expire'
 		);
@@ -1467,6 +1468,7 @@ class UrlEncoder extends EncodeDecoderBase {
 					AND field_id=' . $this->databaseConnection->fullQuoteStr($configuration['id_field'], 'tx_realurl_uniqalias') . '
 					AND tablename=' . $this->databaseConnection->fullQuoteStr($configuration['table'], 'tx_realurl_uniqalias') . '
 					AND lang=' . intval($languageUid) . '
+					AND page_id=' . intval($this->urlParameters['id']) . '
 					AND expire=0', array('expire' => time() + 24 * 3600 * ($configuration['expireDays'] ? $configuration['expireDays'] : 60)));
 
 			// Store new alias
@@ -1476,7 +1478,8 @@ class UrlEncoder extends EncodeDecoderBase {
 				'field_id' => $configuration['id_field'],
 				'value_alias' => $uniqueAlias,
 				'value_id' => $idValue,
-				'lang' => $languageUid
+				'lang' => $languageUid,
+				'page_id' => $this->urlParameters['id']
 			);
 			$this->databaseConnection->exec_INSERTquery('tx_realurl_uniqalias', $insertArray);
 			$aliasRecordId = $this->databaseConnection->sql_insert_id();

--- a/Configuration/TCA/tx_realurl_uniqalias.php
+++ b/Configuration/TCA/tx_realurl_uniqalias.php
@@ -83,6 +83,13 @@ $GLOBALS['TCA']['tx_realurl_uniqalias'] = array(
 				'eval' => 'required',
 			)
 		),
+		'page_id' => array(
+			'label' => 'LLL:EXT:realurl/Resources/Private/Language/locallang_db.xlf:tx_realurl_uniqalias.page_id',
+			'config' => array(
+				'type' => 'input',
+				'eval' => 'required',
+			)
+		),
 	),
 	'types' => array(
 		'types' => array(

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -63,6 +63,9 @@
 			<trans-unit id="module.aliases.edit.alias_info.field_value">
 				<source>Field value:</source>
 			</trans-unit>
+			<trans-unit id="module.aliases.edit.alias_info.page_id">
+				<source>Page id:</source>
+			</trans-unit>
 			<trans-unit id="module.aliases.edit.saved">
 				<source>Alias successfully updated.</source>
 			</trans-unit>
@@ -110,6 +113,9 @@
 			</trans-unit>
 			<trans-unit id="module.tableHeader.language">
 				<source>Language</source>
+			</trans-unit>
+			<trans-unit id="module.tableHeader.page_id">
+				<source>Page id</source>
 			</trans-unit>
 			<trans-unit id="module.tableHeader.expire">
 				<source>Expires</source>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -60,6 +60,9 @@
 			<trans-unit id="tx_realurl_uniqalias.field_id">
 				<source>Field id:</source>
 			</trans-unit>
+			<trans-unit id="tx_realurl_uniqalias.page_id">
+				<source>Page id:</source>
+			</trans-unit>
 			<trans-unit id="tx_realurl_urldata">
 				<source>RealURL URL Data</source>
 			</trans-unit>

--- a/Resources/Private/Templates/Aliases/Edit.html
+++ b/Resources/Private/Templates/Aliases/Edit.html
@@ -29,6 +29,12 @@
 			</div>
 		</div>
 		<div class="form-group">
+			<label class="col-sm-2"><f:translate key="LLL:EXT:realurl/Resources/Private/Language/locallang.xlf:module.aliases.edit.alias_info.page_id"/></label>
+			<div class="col-sm-10">
+				<p>{alias.pageId}</p>
+			</div>
+		</div>
+		<div class="form-group">
 			<label class="col-sm-2" for="aliasValue"><f:translate key="LLL:EXT:realurl/Resources/Private/Language/locallang.xlf:module.aliases.edit.alias_value"/></label>
 			<div class="col-sm-10">
 				<input class="form-control" id="aliasValue" name="tx_realurl_web_realurlrealurl[valueAlias]" value="{alias.valueAlias}"/>

--- a/Resources/Private/Templates/Aliases/Index.html
+++ b/Resources/Private/Templates/Aliases/Index.html
@@ -77,6 +77,7 @@
 					<th><f:translate key="module.tableHeader.alias"/></th>
 					<th class="col-sm-1"><f:translate key="module.tableHeader.id"/></th>
 					<th class="col-sm-2"><f:translate key="module.tableHeader.language"/></th>
+					<th class="col-sm-2"><f:translate key="module.tableHeader.page_id"/></th>
 					<th class="col-sm-2"><f:translate key="module.tableHeader.expire"/></th>
 				</tr>
 				<f:for each="{aliases}" as="alias">
@@ -107,6 +108,7 @@
 		<td>{alias.valueAlias}</td>
 		<td class="col-sm-1">{alias.valueId}</td>
 		<td class="col-sm-2">{d:languageFromId(language: alias.lang)}</td>
+		<td class="col-sm-2">{alias.pageId}</td>
 		<td class="col-sm-2">
 			<f:if condition="{alias.expire}">
 				<f:then>

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -11,6 +11,7 @@ CREATE TABLE tx_realurl_uniqalias (
 	value_id int(11) DEFAULT '0' NOT NULL,
 	lang int(11) DEFAULT '0' NOT NULL,
 	expire int(11) DEFAULT '0' NOT NULL,
+	page_id INT(11) DEFAULT '0' NOT NULL,
 
 	PRIMARY KEY (uid),
 	KEY parent (pid),


### PR DESCRIPTION
With this commit the page id is stored with each alias. So an alias can be
used more than once as it is identified by the page on which the record is shown.
With this commit the behaviour of aliases is similar to the beaviour of pages:
The path segment is unique inside of the parent page.
While decoding preVars we have no page id, so we have to ignore it.