### PR TITLE
[BUGFIX] UrlDecoder should handle multibyte URLs, smelly solution

### DIFF
--- a/Classes/Decoder/UrlDecoder.php
+++ b/Classes/Decoder/UrlDecoder.php
@@ -1067,7 +1067,7 @@ class UrlDecoder extends EncodeDecoderBase implements SingletonInterface {
 
 					$extension = '.' . pathinfo($fileNameSegment, PATHINFO_EXTENSION);
 					if (in_array($extension, $validExtensions)) {
-						$fileNameSegment = pathinfo($fileNameSegment, PATHINFO_FILENAME);
+                        $fileNameSegment = explode('.', $fileNameSegment)[0];
 					}
 					// If no match, we leave it as is => 404.
 				}


### PR DESCRIPTION
as described in https://github.com/dmitryd/typo3-realurl/issues/578
This is probably not an elegant solution, but at least it highlights what the problem is and shows a possible solution. Not sure if it is failsafe for all possible circumstances.