### PR TITLE
Enable 404 Error Handling for Userfunc

### DIFF
--- a/Classes/Decoder/UrlDecoder.php
+++ b/Classes/Decoder/UrlDecoder.php
@@ -834,6 +834,10 @@ class UrlDecoder extends EncodeDecoderBase implements SingletonInterface {
 			if (is_numeric($value) || is_string($value)) {
 				$requestVariables[$configuration['GETvar']] = $value;
 				$result = TRUE;
+			} else {
+				if ($configuration['enable404forInvalidAlias']) {
+					$this->throw404('Could not find element with id or name like "' . $value . '".');
+				}
 			}
 		}
 


### PR DESCRIPTION
Because of some old content in the Google Index i tried to get a 404 Error for no longer existing subpages configured via userfunc in the fixedPostVars.
So I update the UrlDecoder Class and added the following to the realurl configuration:
GETvar' => 'myVar',
'enable404forInvalidAlias' => 1,
'userFunc' => ....

If there was already an existing way to do this, I'm sorry I wasn't able to find it. :)