### PR TITLE
Give also the IP address

### DIFF
--- a/Classes/Encoder/UrlEncoder.php
+++ b/Classes/Encoder/UrlEncoder.php
@@ -1596,10 +1596,16 @@ class UrlEncoder extends EncodeDecoderBase {
 		}
 
 		if (!$isValidLanguageUid) {
+			if (!empty($_SERVER['HTTP_CLIENT_IP'])) {
+		                $ipAddress = $_SERVER['HTTP_CLIENT_IP'];
+            		} else {
+                		$ipAddress = GeneralUtility::getIndpEnv('REMOTE_ADDR');
+            		}
 			$message = sprintf(
-				'Bad "L" parameter ("%s") was detected by realurl. ' .
+				'Bad "L" parameter ("%s") was detected by realurl for IP %s. ' .
 				'Page caching is disabled to prevent spreading of wrong "L" value.',
-				addslashes($sysLanguageUid)
+				addslashes($sysLanguageUid),
+				$ipAddress
 			);
 			$this->tsfe->set_no_cache($message);
 			$this->logger->error($message);


### PR DESCRIPTION
It is necessary to be able to track Dos attackers who misuse the realurl feature of writing continuously into the PHP error_log file.