### PR TITLE
[BUGFIX] use requireOnce of the GeneralUtility to load the default config

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -29,11 +29,11 @@ if (!function_exists('includeRealurlConfiguration')) {
 		$realurlConfigurationFile = trim($configuration['configFile']);
 		if ($realurlConfigurationFile && @file_exists(PATH_site . $realurlConfigurationFile)) {
 			/** @noinspection PhpIncludeInspection */
-			require_once(PATH_site . $realurlConfigurationFile);
+			\TYPO3\CMS\Core\Utility\GeneralUtility::requireOnce(PATH_site . $realurlConfigurationFile);
 		}
 		elseif ($configuration['enableAutoConf'] && file_exists(PATH_site . TX_REALURL_AUTOCONF_FILE)) {
 			/** @noinspection PhpIncludeInspection */
-			require_once(PATH_site . TX_REALURL_AUTOCONF_FILE);
+			\TYPO3\CMS\Core\Utility\GeneralUtility::requireOnce(PATH_site . TX_REALURL_AUTOCONF_FILE);
 		}
 
 		if (is_array($existingConfiguration)) {


### PR DESCRIPTION
#606 

The change to `require_once` in 2.3.2 breaks TYPO3 8 (and older) setups where `$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl']['_DEFAULT']` is accessed for example in `typo3conf/RealUrlConfiguration.php` and results in `null` and not the expected `Array`.

Before this it did work. 2.3.1 was still fine.