### PR TITLE
[TASK] Make URLs case sensitive

### DIFF
--- a/Classes/Decoder/UrlDecoder.php
+++ b/Classes/Decoder/UrlDecoder.php
@@ -542,7 +542,7 @@ class UrlDecoder extends EncodeDecoderBase implements SingletonInterface {
 			$remainingPathSegments = $savedRemainingPathSegments;
 		}
 		if ($result && $this->expiredPath) {
-			$startPosition = (int)strpos($this->speakingUri, $this->expiredPath);
+			$startPosition = (int)stripos($this->speakingUri, $this->expiredPath);
 			if ($startPosition !== FALSE) {
 				$newUrl = substr($this->speakingUri, 0, $startPosition) .
 					$result->getPagePath() .
@@ -1526,6 +1526,11 @@ class UrlDecoder extends EncodeDecoderBase implements SingletonInterface {
 						$this->expiredPath = $cacheEntry->getPagePath();
 						$cacheEntry = $nonExpiredCacheEntry;
 					}
+				}
+				// Check if the cached result differs in case spelling
+				elseif ($path !== $cacheEntry->getPagePath() && strtolower($path) === strtolower($cacheEntry->getPagePath())) {
+					$this->isExpiredPath = TRUE;
+					$this->expiredPath = $path;
 				}
 				$result = $cacheEntry;
 			} else {


### PR DESCRIPTION
As explained in #482 RealUrl is case sensitive for non-cached URLs, but it accepts different case spelling for cached results.

Scenario:
1. Open http://mysite/HOME/ => it fails
2. Open http://mysite/home/ => page is loaded, cache is filled
3. Open http://mysite/HOME/ again => page is loaded

This is problematic because it leads to duplicate URLs for the same content.

Solution: When a URL is fetched from the cache which does not match the case spelling, treat it as expired and redirect to the correct URL.

Closes #482 