### PR TITLE
cleanup $this->originalUrlParameters['L']

### DIFF
--- a/Classes/Encoder/UrlEncoder.php
+++ b/Classes/Encoder/UrlEncoder.php
@@ -618,7 +618,7 @@ class UrlEncoder extends EncodeDecoderBase {
 		unset($rootLineIsOk);
 
 		$languageExceptionUids = (string)$this->configuration->get('pagePath/languageExceptionUids');
-		$enableLanguageOverlay = ((int)$this->originalUrlParameters['L'] > 0) && (empty($languageExceptionUids) || !GeneralUtility::inList($languageExceptionUids, $this->sysLanguageUid));
+		$enableLanguageOverlay = ($this->sysLanguageUid > 0) && (empty($languageExceptionUids) || !GeneralUtility::inList($languageExceptionUids, $this->sysLanguageUid));
 
 		$components = array();
 		$reversedRootLine = array_reverse($rootLine);
@@ -636,7 +636,7 @@ class UrlEncoder extends EncodeDecoderBase {
 				continue;
 			}
 			if ($enableLanguageOverlay) {
-				$overlay = $this->pageRepository->getPageOverlay($page, (int)$this->originalUrlParameters['L']);
+				$overlay = $this->pageRepository->getPageOverlay($page, $this->sysLanguageUid);
 				if (is_array($overlay)) {
 					$page = $overlay;
 					unset($overlay);

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-    "name": "dmitryd/typo3-realurl",
+    "name": "svendeka/typo3-realurl",
     "type": "typo3-cms-extension",
-    "description": "Speaking URLs for TYPO3",
+    "description": "fork of dmitryd/typo3-realurl - Speaking URLs for TYPO3",
     "homepage": "https://github.com/dmitryd/typo3-realurl",
     "version": "2.4.0",
     "time": "2018-07-09",


### PR DESCRIPTION
now using $this->sysLanguageUid instead -looked forgotten, as was is used 
in createPathComponentThroughOverride
but not in createPathComponentUsingRootline()

using originalUrlParameters['L'] blocked me from using an alternative Language-Param with own behaviour