### PR TITLE
[TASK] Mark as compatible with PHP 7.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require": {
         "typo3/cms-core": ">=6.2.0,<9.0.0",
-        "php": ">=5.4.0,<7.3.0",
+        "php": ">=5.4.0,<7.4.0",
         "ext-mbstring": "*"
     },
     "require-dev": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -26,7 +26,7 @@ $EM_CONF[$_EXTKEY] = array (
     'depends' => 
     array (
       'typo3' => '6.2.0-8.9.999',
-      'php' => '5.4.0-7.2.999',
+      'php' => '5.4.0-7.3.999',
       'scheduler' => '6.2.0-8.9.999',
     ),
     'conflicts' => 


### PR DESCRIPTION
According to PHPStan and to our tests realurl has no compatiblity issues with PHP 7.3