### PR TITLE
[FEATURE] Support of no match with "bypass" behavior in user functions

### DIFF
--- a/Classes/Decoder/UrlDecoder.php
+++ b/Classes/Decoder/UrlDecoder.php
@@ -827,6 +827,14 @@ class UrlDecoder extends EncodeDecoderBase implements SingletonInterface {
 				$requestVariables[$configuration['GETvar']] = $value;
 				$result = TRUE;
 			}
+			elseif ($value === TRUE) {
+				// If the user function returns the special value true
+				// => handle it like no match with "bypass"
+				if (!$isFakeValue) {
+					array_unshift($pathSegments, $getVarValue);
+				}
+				$result = TRUE;
+			}
 		}
 
 		return $result;

--- a/Classes/Encoder/UrlEncoder.php
+++ b/Classes/Encoder/UrlEncoder.php
@@ -938,6 +938,11 @@ class UrlEncoder extends EncodeDecoderBase {
 				$segments[] = rawurlencode($getVarValue);
 				$result = TRUE;
 			}
+			elseif ($getVarValue === TRUE) {
+				// If the user function returns the special value true
+				// => handle it like no match with "bypass"
+				$result = TRUE;
+			}
 		}
 
 		return $result;


### PR DESCRIPTION
This allows to remove empty segments for segments handled by userFunc instead of valueMap.

A common use case could be to transform all controller and action names from lowerCamelCase to lowercase-with-hyphens and remove the empty default action of an extbase plugin:

`realurl_conf.php`:
```
'postVarSets' =>
    array(
        '_DEFAULT' =>
            array(
                'events' =>
                    array(
                        array(
                            'GETvar' => 'tx_myextension_event[controller]',
                            'userFunc' => 'My\MyExtension\Hooks\RealUrlData->getLowerCaseWithHyphenOrRemoveIfEmpty',
                        ),
                        array(
                            'GETvar' => 'tx_myextension_event[action]',
                            'userFunc' => 'My\MyExtension\Hooks\RealUrlData->getLowerCaseWithHyphenOrRemoveIfEmpty',
                        ),
                        array(
                            'GETvar' => 'tx_myextension_event[date]',
                        ),
                    ),
```

`RealUrlData.php`:
```
namespace My\MyExtension\Hooks;

use DmitryDulepov\Realurl\Configuration\ConfigurationReader;
use DmitryDulepov\Realurl\Decoder\UrlDecoder;
use DmitryDulepov\Realurl\Encoder\UrlEncoder;
use DmitryDulepov\Realurl\Utility;
use TYPO3\CMS\Core\Utility\GeneralUtility;

class RealUrlData {

    /**
     * @var \DmitryDulepov\Realurl\Utility
     */
    protected $utilityEncode;

    /**
     * Encode or decode lowercase string with hyphens
     *
     * @param array $params
     * @param UrlEncoder|UrlDecoder $pObj
     *
     * @return string|bool
     */
    public function getLowerCaseWithHyphenOrRemoveIfEmpty(array &$params, $pObj) {
        if (empty($params['value'])) {
            return TRUE;
        }

        if ($pObj instanceof UrlEncoder) {
            $result = $this->getLowerCaseWithHyphenByCamelCase($params);
        } else {
            $result = $this->getLowerCamelCaseByLowerCaseWithHyphen($params);
        }

        return $result;
    }

    /**
     * Get lowercase string with hyphens
     *
     * @param array $params
     *
     * @return string
     */
    private function getLowerCaseWithHyphenByCamelCase(array &$params) {
        $result = $this->getUtilityEncode()->convertToSafeString(
            GeneralUtility::camelCaseToLowerCaseUnderscored($params['value'])
        );

        return $result;
    }

    /**
     * Get lower camel case string
     *
     * @param array $params
     *
     * @return string
     */
    private function getLowerCamelCaseByLowerCaseWithHyphen(array &$params) {
        $result = GeneralUtility::underscoredToLowerCamelCase(
            $this->getUtilityEncode()->convertToSafeString($params['value'], '_')
        );

        return $result;
    }

    /**
     * Get encoding utilities of tx_realurl
     *
     * @return Utility
     */
    protected function getUtilityEncode() {
        if (!is_object($this->utilityEncode)) {
            $configuration = GeneralUtility::makeInstance(
                'DmitryDulepov\Realurl\Configuration\ConfigurationReader',
                ConfigurationReader::MODE_ENCODE
            );
            $this->utilityEncode = GeneralUtility::makeInstance(
                'DmitryDulepov\Realurl\Utility',
                $configuration
            );
        }

        return $this->utilityEncode;
    }
}
```