### PR TITLE
[TASK] Provide the extension key for composer based installs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,6 +64,7 @@
     "extra": {
         "typo3/cms": {
             "cms-package-dir": "{$vendor-dir}/typo3/cms",
+            "extension-key": "realurl",
             "web-dir": ".Build/Web"
         }
     }


### PR DESCRIPTION
By the removal of the deprecated replace entry with the commit https://github.com/dmitryd/typo3-realurl/commit/76cc5e73be6ed40d778e654007d49b4036acf121 the extension key is also changed for composer based installs because the key was resolved from this line see https://github.com/TYPO3/CmsComposerInstallers/blob/master/src/Plugin/Util/ExtensionKeyResolver.php#L37. Therefor a new extra option was introduced by the CmsComposerInstallers which is also the recommended way by the core to define a extension key see https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ComposerJson/Index.html#minimal-composer-json.